### PR TITLE
Better way of determining the distribution codename

### DIFF
--- a/fabtools/deb.py
+++ b/fabtools/deb.py
@@ -61,4 +61,6 @@ def distrib_codename():
     Get the codename of the distrib
     """
     with settings(hide('running', 'stdout')):
+        if run('which lsb_release'):
+            return run('lsb_release --codename --short')
         return run('grep DISTRIB_CODENAME /etc/lsb-release').split('=')[1]


### PR DESCRIPTION
On my test system (Debian Squeeze) there is no /etc/lsb-release.
The lsb_release tool seems to be a standard, reliable way to get this
information.
