### PR TITLE
Add method to get dpkg selections, by status

### DIFF
--- a/fabtools/deb.py
+++ b/fabtools/deb.py
@@ -56,6 +56,20 @@ def preseed_package(pkg_name, preseed):
         sudo('echo "%(pkg_name)s %(q_name)s %(q_type)s %(q_answer)s" | debconf-set-selections' % locals())
 
 
+def get_selections():
+    """
+    Get the state of dkpg selections
+    Returns dict with state => [packages]
+    """
+    with settings(hide('stdout')):
+        res = sudo('dpkg --get-selections')
+    selections = dict()
+    for line in res.splitlines():
+        package, status = line.split()
+        selections.setdefault(status, list()).append(package)
+    return selections
+
+
 def distrib_codename():
     """
     Get the codename of the distrib


### PR DESCRIPTION
Though the code below has no place in fabtools in my opinion, I'm putting it here to show an use case:

``` python
for pkg in fabtools.deb.get_selections().get('deinstall', list()):
    if confirm('Purge %s?' % pkg):
        pkgs.append(pkg)
if len(pkgs):
    fabtools.deb.uninstall(pkgs, purge=True)
```
