### PR TITLE
Fix md5sum returns with unavailable files

### DIFF
--- a/fabtools/files.py
+++ b/fabtools/files.py
@@ -57,4 +57,7 @@ def md5sum(filename, use_sudo=False):
     func = use_sudo and sudo or run
     with settings(hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
         res = func('md5sum %(filename)s' % locals())
+    if res.failed:
+        warn(res)
+        return None
     return res.split()[0]

--- a/tests/fabfile.py
+++ b/tests/fabfile.py
@@ -1,5 +1,6 @@
 import os
 from tempfile import NamedTemporaryFile
+import hashlib
 
 from fabric.api import *
 from fabtools import require
@@ -35,6 +36,13 @@ def files():
         os.remove(tmp_file.name)
         assert fabtools.files.is_file('baz')
         assert run('cat baz') == baz_contents, run('cat baz')
+
+        # Check md5 sums (unavailable, empty, with content)
+        run('touch f1')
+        run('echo -n hello > f2')
+        assert fabtools.files.md5sum('doesnotexist') is None
+        assert fabtools.files.md5sum('f1') == hashlib.md5('').hexdigest()
+        assert fabtools.files.md5sum('f2') == hashlib.md5('hello').hexdigest()
 
 
 def python():


### PR DESCRIPTION
Before it would return the "md5sum:" string which has little meaning.
Now None is returned, and the error is issued as a warning (which is
easy to hide if wanted).

This also adds tests for normal cases.
