### PR TITLE
Postgres: Allow locale and encoding to be passed through 

### DIFF
--- a/fabtools/require/postgres.py
+++ b/fabtools/require/postgres.py
@@ -31,9 +31,11 @@ def user(name, password):
         create_user(name, password)
 
 
-def database(name, owner, template='template0'):
+def database(name, owner, template='template0', encoding='UTF8',
+             locale='en_US.UTF-8'):
     """
     Require a PostgreSQL database
     """
     if not database_exists(name):
-        create_database(name, owner, template)
+        create_database(name, owner, template=template, encoding=encoding,
+            locale=locale)

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -34,3 +34,19 @@ class FilesTestCase(unittest.TestCase):
         self._file(contents='This is a test', verify_remote=True)
         self.assertTrue(is_file.called)
         self.assertTrue(md5sum.called)
+
+
+class PostgresTestCase(unittest.TestCase):
+
+    @mock.patch('fabtools.require.postgres.create_database')
+    @mock.patch('fabtools.require.postgres.database_exists')
+    def test_params_respected(self, database_exists, create_database):
+        """ If require.database is called, ensure that the template, encoding
+        and locale parameters are passed through to the underlying
+        create_database call """
+        from fabtools import require
+        database_exists.return_value = False
+        require.postgres.database('foo', 'bar', locale='some_locale',
+            encoding='some_encoding', template='some_template')
+        create_database.assert_called_with('foo', 'bar', locale='some_locale',
+            encoding='some_encoding', template='some_template')


### PR DESCRIPTION
This allows require.postgres.database to specify locale and encoding (which is present in the underlying API anyway.)
