### PR TITLE
Use 'update' rather than 'reload' to avoid unnecessary restarting

### DIFF
--- a/fabtools/require/supervisor.py
+++ b/fabtools/require/supervisor.py
@@ -4,7 +4,7 @@ Idempotent API for managing supervisor processes
 from __future__ import with_statement
 
 from fabtools.files import watch
-from fabtools.supervisor import *
+from fabtools.supervisor import update_config, process_status, start_process
 
 
 def process(name, **kwargs):
@@ -12,7 +12,6 @@ def process(name, **kwargs):
     Require a supervisor process
     """
     from fabtools import require
-
     require.deb.package('supervisor')
     require.service.started('supervisor')
 
@@ -30,7 +29,8 @@ def process(name, **kwargs):
 
     # Upload config file
     filename = '/etc/supervisor/conf.d/%(name)s.conf' % locals()
-    with watch(filename, True, reload_config):
+
+    with watch(filename, True, update_config):
         require.file(filename, contents='\n'.join(lines), use_sudo=True)
 
     # Start the process if needed

--- a/fabtools/supervisor.py
+++ b/fabtools/supervisor.py
@@ -13,6 +13,15 @@ def reload_config():
     sudo("supervisorctl reload")
 
 
+def update_config():
+    """
+    Reread and update supervisor job configurations. Less heavy-handed than
+    a full reload, as it doesn't restart the backend supervisor process and
+    all managed processes.
+    """
+    sudo("supervisorctl update")
+
+
 def process_status(name):
     """
     Get the status of a supervisor process


### PR DESCRIPTION
Hi,

Just wanted to get your opinion on this change. It adds an 'update' action to supervisor.py, and uses that instead of reload when supervisor service conf files change. 

Reload's quite heavy-handed, and causes supervisor itself to restart, and all managed processes. I found occasionally that child processes didn't shut down properly - especially when I add several services in quick succession, as my deploys often do - and it isn't necessary to restart all services just because one has changed.

What do you think?

Cheers,
Dan
