### PR TITLE
need_restart is not actually change on config change in require/redis.py

### DIFF
--- a/fabtools/require/redis.py
+++ b/fabtools/require/redis.py
@@ -91,9 +91,11 @@ def instance(name, version=VERSION, **kwargs):
     config_filename = '/etc/redis/%(name)s.conf' % locals()
 
     # Upload config file
-    need_restart = False
+    context = dict(need_restart=False)
+
     def on_change():
-        need_restart = True
+        context['need_restart'] = True
+
     with watch(config_filename, True, on_change):
         require.file(config_filename, contents='\n'.join(lines),
             use_sudo=True, owner='redis')
@@ -104,5 +106,5 @@ def instance(name, version=VERSION, **kwargs):
         user='redis',
         directory='/var/run/redis',
         command="%(redis_server)s %(config_filename)s" % locals())
-    if need_restart:
+    if context['need_restart']:
         fabtools.supervisor.restart_process(process_name)


### PR DESCRIPTION
You can read variables from parent context in python2, but
you can't directly write to them. This is adressed by word
nonlocal in python3. See http://www.python.org/dev/peps/pep-3104/ 
for details. Fixed this by using workaround as described in 
http://stackoverflow.com/questions/3190706/nonlocal-keyword-in-python-2-x
