### PR TITLE
Tests fail if vagrant isn't installed

### DIFF
--- a/fabtools/tests/vagrant.py
+++ b/fabtools/tests/vagrant.py
@@ -50,7 +50,8 @@ def base_boxes():
     if boxes is not None:
         return boxes.split()
     else:
-        res = local('vagrant box list', capture=True)
+        with settings(warn_only=True):
+            res = local('vagrant box list', capture=True)
         if res.failed:
             return []
         else:


### PR DESCRIPTION
It fix this : 

```
$ unit2 discover               
[localhost] local: vagrant box list

Fatal error: local() encountered an error (return code 127) while executing 'vagrant box list'

Aborting.
zsh: exit 1     unit2 discover
```

Voilà 
