### PR TITLE
Support for node JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ share/
 fabtools/tests/.vagrant
 fabtools/tests/Vagrantfile
 *.pyc
+*.swp

--- a/fabtools/nodejs.py
+++ b/fabtools/nodejs.py
@@ -1,0 +1,77 @@
+"""
+NodeJS environments and packages
+================================
+
+Packages are managed with npm.
+"""
+from fabric.api import run, sudo, cd
+from fabtools import require
+
+
+def install_nodejs(version="0.8.9"):
+    """
+    Installing Node JS 0.8.9 by default. This script works only for recent
+    version of Node JS.
+    """
+    require.deb.packages([
+        "make",
+        "openssl",
+        "python",
+        "libssl-dev",
+        "g++",
+    ])
+
+    filename = "node-v{version}.tar.gz".format(**locals())
+    foldername = filename[0:-7]
+
+    run("wget http://nodejs.org/dist/v{version}/{filename}".format(**locals()))
+    run("tar -xzf {filename}".format(filename=filename))
+    with cd(foldername):
+        run("./configure ; make")
+        sudo("make install")
+    run('rm {filename} ; rm -rf {foldername}'.format(**locals()))
+
+
+def install(package=None, version=None, global_install=True):
+    """
+    Install given npm package. If global_install is set to false, package
+    is installed locally.
+
+    If no package is given npm install is run inside current directory
+    and install locally all files given by package.json file that should
+    be located at the root of curent directory.
+    """
+    if package:
+        if version:
+            package += "@{version}".format(version=version)
+
+        if global_install:
+            sudo("npm install -g {package}".format(package=package))
+        else:
+            run("npm install -l {package}".format(package=package))
+    else:
+        run("npm install")
+
+
+def update(package, global_install=True):
+    """
+    update given pack
+    """
+    if global_install:
+        sudo("npm update -g {package}".format(package=package))
+    else:
+        run("npm update -l {package}".format(package=package))
+
+
+def uninstall(package, version=None, global_uninstall=True):
+    """
+    Uninstall given npm package. If global_install is set to false, package
+    is uninstalled locally.
+    """
+    if version:
+        package += "@{version}".format(version=version)
+
+    if global_uninstall:
+        sudo("npm uninstall -g {package}".format(package=package))
+    else:
+        sudo("npm uninstall -l {package}".format(package=package))


### PR DESCRIPTION
This fabtools add-on allows :
- Node JS installation, 0.8.9 by default (it works only for recent version of nodejs)
- Npm package installation (global and local)
- Npm package update (global and local)
- Npm package uninstallation (global and local)
