### PR TITLE
Distro-specific implementation

### DIFF
--- a/fabtools/__init__.py
+++ b/fabtools/__init__.py
@@ -15,3 +15,8 @@ import fabtools.user
 
 import fabtools.require
 icanhaz = require
+
+from collections import defaultdict
+default_distro = 'deb'
+distros = defaultdict(lambda: default_distro)
+del defaultdict

--- a/fabtools/distro_specific.py
+++ b/fabtools/distro_specific.py
@@ -1,0 +1,43 @@
+from functools import update_wrapper
+from fabric.state import env
+import fabtools
+
+def current_distro():
+    return fabtools.distros[env.host]
+
+registry = {}
+
+class DistroSpecific(object):
+    def __init__(self):
+        self.default = None
+        self.distros = {}
+    def __call__(self, *args):
+        function = self.distros.get(current_distro(), self.default)
+        if function is None:
+            raise TypeError("no match")
+        return function(*args)
+    def register(self, distro, function):
+        if distro in self.distros:
+            raise TypeError("duplicate registration")
+        if distro:
+            self.distros[distro] = function
+        else:
+            self.default = function
+
+
+def distro(distro=None):
+    def register(function):
+        key = '%s#%s'%(function.__module__, function.__name__)
+        ds = registry.get(key)
+        if ds is None:
+            ds = registry[key] = DistroSpecific()
+            update_wrapper(ds, function)
+        ds.register(distro, function)
+        return ds
+    return register
+
+
+def check_distro_support(distro):
+    for name, function in registry.iteritems():
+        if not distro in function.distros:
+            print '%s does not support %s'%(name, distro)

--- a/fabtools/service.py
+++ b/fabtools/service.py
@@ -12,8 +12,9 @@ and traditional SysV-style ``/etc/init.d/`` scripts.
 from __future__ import with_statement
 
 from fabric.api import *
+from fabtools.distro_specific import distro
 
-
+@distro('deb')
 def is_running(service):
     """
     Check if a service is running.
@@ -30,6 +31,14 @@ def is_running(service):
         return res.succeeded
 
 
+@distro('arch')
+def is_running(service):
+    with settings(hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
+        res = sudo('rc.d list %(service)s --started' % locals())
+        return bool(res)
+
+
+@distro('deb')
 def start(service):
     """
     Start a service.
@@ -45,6 +54,12 @@ def start(service):
     sudo('service %(service)s start' % locals())
 
 
+@distro('arch')
+def start(service):
+    sudo('rc.d start %(service)s' % locals())
+
+
+@distro('deb')
 def stop(service):
     """
     Stop a service.
@@ -60,6 +75,12 @@ def stop(service):
     sudo('service %(service)s stop' % locals())
 
 
+@distro('arch')
+def stop(service):
+    sudo('rc.d stop %(service)s' % locals())
+
+
+@distro('deb')
 def restart(service):
     """
     Restart a service.
@@ -75,3 +96,8 @@ def restart(service):
             fabtools.service.start('foo')
     """
     sudo('service %(service)s restart' % locals())
+
+
+@distro('arch')
+def restart(service):
+    sudo('rc.d restart %(service)s' % locals())


### PR DESCRIPTION
Hello

This work is not merge ready for now, but I would like your opinion on the way I plan to do it.

First of all, I added two variables that the user should edit : `fabtools.distros`, which is a host/distro dictionary and  `fabtools.default_distro`, which is the distro that should be used if not distro is specified for the host.

Then, I have a `distro` decorator which is backed by some kind of multimethod : decorate a function with `@distro("deb")`, and it will only be run if the host is running debian (according to `fabtools.distros`). The documentation of the first defined function is kept.

Doing it this enabled me to write a simple `check_distro_support` function that lists all the function not supported that do not support a given distro.

As an example of usage, I've made `fabtools.service` compatible with arch.

I think I should add some distro recognition for this to be convenient.

So, do you like this ? Anything you would prefer to be different ? Can I start a adding full support for arch based in this ?
