### PR TITLE
Fabric 1.4 or later is now required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='http://fabtools.readthedocs.org/',
     license='BSD',
     install_requires=[
-        "fabric>=1.2.0",
+        "fabric>=1.4.0",
     ],
     setup_requires=[],
     tests_require=[


### PR DESCRIPTION
Because of (at least) fabric.utils.error.
