### PR TITLE
"adduser" - change incorrect command.

### DIFF
--- a/fabtools/user.py
+++ b/fabtools/user.py
@@ -48,4 +48,4 @@ def create(name, home=None, shell=None, uid=None, gid=None, groups=None,
     if disabled_login:
         options.append('--disabled-login')
     options = " ".join(options)
-    sudo('useradd %(options)s %(name)s' % locals())
+    sudo('adduser %(options)s %(name)s' % locals())


### PR DESCRIPTION
adduser and useradd is different commands.

see example:

~$ adduser --help

adduser [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--firstuid ID] [--lastuid ID] [--gecos GECOS] [--ingroup GROUP | --gid ID]
[--disabled-password] [--disabled-login] [--encrypt-home] USER
   Add a normal user

adduser --system [--home DIR] [--shell SHELL] [--no-create-home] [--uid ID]
[--gecos GECOS] [--group | --ingroup GROUP | --gid ID] [--disabled-password]
[--disabled-login] USER
   Add a system user

adduser --group [--gid ID] GROUP
addgroup [--gid ID] GROUP
   Add a user group

addgroup --system [--gid ID] GROUP
   Add a system group

adduser USER GROUP
   Add an existing user to an existing group

general options:
  --quiet | -q      don't give process information to stdout
  --force-badname   allow usernames which do not match the
                    NAME_REGEX[_SYSTEM] configuration variable
  --help | -h       usage message
  --version | -v    version number and copyright
  --conf | -c FILE  use FILE as configuration file
