### PR TITLE
Add reload() and force_reload() service functions.

### DIFF
--- a/fabtools/service.py
+++ b/fabtools/service.py
@@ -87,6 +87,10 @@ def reload(service):
 
         # Reload service
         fabtools.service.reload('foo')
+
+    .. warning::
+
+        The service need to support the ``reload`` operation.
     """
     sudo('service %(service)s reload' % locals())
 
@@ -101,5 +105,9 @@ def force_reload(service):
 
         # Force reload service
         fabtools.service.force_reload('foo')
+
+    .. warning::
+
+        The service need to support the ``force-reload`` operation.
     """
     sudo('service %(service)s force-reload' % locals())


### PR DESCRIPTION
Many services supports `reload` and `force-reload` operations to reload configuration.
These operations are very usefull (ex: `service nginx reload` to reload nginx config without turning down the service).

They are missing from `fabtools.service` so I added them.
