### PR TITLE
Add support for BSD's stat command (so require.directory works on OS X)

### DIFF
--- a/fabtools/files.py
+++ b/fabtools/files.py
@@ -78,8 +78,15 @@ def mode(path, use_sudo=False):
     an octal number.
     """
     func = use_sudo and sudo or run
-    with settings(hide('running', 'stdout')):
-        return func('stat -c %%a "%(path)s"' % locals())
+    # I'd prefer to use quiet=True, but that's not supported with older
+    # versions of Fabric.
+    with settings(hide('running', 'stdout'), warn_only=True):
+        result = func('stat -c %%a "%(path)s"' % locals())
+        if result.failed and 'stat: illegal option' in result:
+            # Try the BSD version of stat
+            return func('stat -f %%Op "%(path)s"|cut -c 4-6' % locals())
+        else:
+            return result
 
 
 def upload_template(filename, template, context=None, use_sudo=False,


### PR DESCRIPTION
This commit causes files.owner and files.group (and, notably,
not files.mode) operations to try the BSD flavor of stat if stat fails
with 'stat: illegal option'.  This allows the use of require.directory
on OS X.
