### PR TITLE
use hosts/port instead of host_string for easier overriding with context_managers

### DIFF
--- a/fabtools/vagrant.py
+++ b/fabtools/vagrant.py
@@ -28,8 +28,9 @@ def _settings_dict(config):
     hostname = config['HostName']
     port = config['Port']
 
-    settings['host_string'] = "%s@%s:%s" % (user, hostname, port)
     settings['user'] = user
+    settings['hosts'] = [hostname]
+    settings['port'] = port
     settings['key_filename'] = config['IdentityFile']
     settings['forward_agent'] = (config.get('ForwardAgent', 'no') == 'yes')
     settings['disable_known_hosts'] = True


### PR DESCRIPTION
using hosts/port instead of host_string makes it easier to use context_managers such as:

``` python

with settings(user='username'):
    run('mkdir test')
```

as you don't have to rebuild the host_string to override.
