### PR TITLE
fix confusion between useradd and adduser with --disabled-password

### DIFF
--- a/fabtools/tests/fabfiles/users.py
+++ b/fabtools/tests/fabfiles/users.py
@@ -1,0 +1,23 @@
+from __future__ import with_statement
+
+from fabric.api import *
+from fabtools import require
+import fabtools
+
+
+@task
+def users():
+    """
+    Check user creation
+    """
+    # create default user
+    fabtools.user.create('default')
+    assert fabtools.user.exists('default')
+
+    # create no-login user
+    fabtools.user.create('no-login', disabled_login=True)
+    assert fabtools.user.exists('no-login')
+
+    # require that a user exist
+    require.user('foo')
+    assert fabtools.user.exists('foo')

--- a/fabtools/user.py
+++ b/fabtools/user.py
@@ -16,7 +16,7 @@ def exists(name):
 
 
 def create(name, home=None, shell=None, uid=None, gid=None, groups=None,
-           gecos=None, disabled_password=False, disabled_login=False):
+           gecos=None, disabled_password=True, disabled_login=False):
     """
     Create a new user.
 
@@ -43,9 +43,11 @@ def create(name, home=None, shell=None, uid=None, gid=None, groups=None,
         options.append('--uid %s' % uid)
     if gecos:
         options.append('--gecos "%s"' % gecos)
+    else:
+        options.append('--gecos ""')
     if disabled_password:
         options.append('--disabled-password')
     if disabled_login:
         options.append('--disabled-login')
     options = " ".join(options)
-    sudo('useradd %(options)s %(name)s' % locals())
+    sudo('adduser %(options)s %(name)s' % locals())


### PR DESCRIPTION
It seems there was a confusion between `useradd` and `adduser` as `useradd` doesn't take the --disable-password and --disable-login options. It was causing an error when trying to create a user with these options, at least on Ubuntu.

I solved the issue by switching to a default:

```
$ adduser --disable-password --gecko "" <username>
```

with `disable_password=False`, the user will be prompted with password input
