### PR TITLE
Add create user options - create_group_if_need=True

### DIFF
--- a/fabtools/user.py
+++ b/fabtools/user.py
@@ -4,7 +4,6 @@ Users
 """
 from __future__ import with_statement
 
-from crypt import crypt
 from pipes import quote
 import random
 import string
@@ -24,6 +23,7 @@ _SALT_CHARS = string.ascii_letters + string.digits + './'
 
 
 def _crypt_password(password):
+    from crypt import crypt
     random.seed()
     salt = ''
     for _ in range(2):


### PR DESCRIPTION
If you want create a group with the same name as the user do it now simple.
Use:

   fabtools.user.create('alice', group='alice')

(and fix small bug)

Note: need change docs.
