### PR TITLE
Pass options to add-apt-repository

### DIFF
--- a/fabtools/require/deb.py
+++ b/fabtools/require/deb.py
@@ -57,6 +57,7 @@ def ppa(name, options=None):
         options = []
     elif isinstance(options, str):
         options = [options]
+    options = " ".join(options)
     source = '%(user)s-%(repo)s-%(distrib)s.list' % locals()
 
     if not is_file(source):


### PR DESCRIPTION
Allows to pass options to ppa()

`require.deb.ppa(ppa, ['-y', '-k my.keyserver.net'])`

Most important being the `-y` assuming yes and getting around the interactive prompt and fabric hanging:

`require.deb.ppa(ppa, '-y')`
