### PR TITLE
PPA verification fix

### DIFF
--- a/fabtools/require/deb.py
+++ b/fabtools/require/deb.py
@@ -59,7 +59,7 @@ def ppa(name):
 
     if not is_file(source):
         package('python-software-properties')
-        sudo('add-apt-repository -y %s' % name)
+        sudo('add-apt-repository %s' % name)
         update_index()
 
 


### PR DESCRIPTION
The method ppa() is supposed to take a ppa name and skip if already installed (with `is_source` method).

1) If you pass a PPA with a `.` like the one from the example (`require.deb.ppa('ppa:chris-lea/node.js'`), it will end up as `_` on Ubuntu (and Debian).

2) The check for the PPA will never work as it's assuming the current directory being where apt look for sources `/etc/apt/sources.list.d`

This PR fixes both issues.

Feel free to comment on it.

Thank you!
