### PR TITLE
Don't call modifyuser if we're not making changes

### DIFF
--- a/fabtools/user.py
+++ b/fabtools/user.py
@@ -125,6 +125,8 @@ def modify(name, comment=None, home=None, move_current_home=False, group=None,
         args.append('-s %s' % quote(shell))
     if uid:
         args.append('-u %s' % quote(uid))
-    args.append(name)
-    args = ' '.join(args)
-    sudo('usermod %s' % args)
+
+    if args:
+        args.append(name)
+        args = ' '.join(args)
+        sudo('usermod %s' % args)


### PR DESCRIPTION
Fix to avoid this error:
out: usermod: no flags given

When requiring a user with no additional details:
require.user('myuser')
