### PR TITLE
[SmartOS] Fixes for pkg.is_installed

### DIFF
--- a/fabtools/pkg.py
+++ b/fabtools/pkg.py
@@ -44,7 +44,7 @@ def is_installed(pkg_name):
     Check if a package is installed.
     """
     with settings(hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
-        res = run("yes 'y' | pkgin list | egrep -qio \"^%(pkg_name)s\"" % locals())
+        res = run("yes 'y' | pkgin list | awk '{print $1}' | egrep -qio \"^%(pkg_name)s\"" % locals())
         if res.succeeded:
             return True
         return False


### PR DESCRIPTION
1) The regex is fixed for packages installed (if you try to install `zip` and have `bzip` installed, `zip` package wont be installed). It also ignores packages descriptions which might include a package name (`dpkg` style)

2) Fix the case where `pkgin` cache is not present. If you run `pkgin list`, `pkgin` will ask to update the database interactively, answering `y`
