### PR TITLE
Fixes #76 using `uname -m` to get system architecture

### DIFF
--- a/fabtools/system.py
+++ b/fabtools/system.py
@@ -73,5 +73,5 @@ def get_arch():
 
     """
     with settings(hide('running', 'stdout')):
-        arch = run('uname -p')
+        arch = run('uname -m')
         return arch


### PR DESCRIPTION
Tested on:
- CentOS 6.3 32
- CentOS 6.3 64
- Lucid 32
- Precise 64
- Wheezy 64
