### PR TITLE
the required file from remote url should be saved to given path.

### DIFF
--- a/fabtools/require/files.py
+++ b/fabtools/require/files.py
@@ -103,7 +103,7 @@ def file(path=None, contents=None, source=None, url=None, md5=None,
             path = os.path.basename(urlparse(url).path)
 
         if not is_file(path) or md5 and md5sum(path) != md5:
-            func('wget --progress=dot:mega %(url)s' % locals())
+            func('wget --progress=dot:mega %(url)s -O %(path)s' % locals())
 
     # 3) A local filename, or a content string, is specified
     else:


### PR DESCRIPTION
for example,

``` python
require.file(path='/tmp/libgit2-0.17.0.tar.gz',
             url='https://github.com/libgit2/libgit2/archive/v0.17.0.tar.gz',
             md5='8fa3a08dc28ecec4280b8677741eef3d')
```

file should be saved to `/tmp/libgit2-0.17.0.tar.gz` instead of `v0.17.0.tar.gz` in current working directory
