### PR TITLE
Vagrant: use host_string instead of hosts 

### DIFF
--- a/fabtools/vagrant.py
+++ b/fabtools/vagrant.py
@@ -29,7 +29,7 @@ def _settings_dict(config):
     port = config['Port']
 
     settings['user'] = user
-    settings['hosts'] = [hostname]
+    settings['host_string'] = hostname
     settings['port'] = port
     settings['key_filename'] = config['IdentityFile']
     settings['forward_agent'] = (config.get('ForwardAgent', 'no') == 'yes')


### PR DESCRIPTION
this fixes the not working vagrant_settings for me. Fabric also complaints about a missing host. 
