### PR TITLE
fix Vagrant 1.1 double quotes from ssh-config

### DIFF
--- a/fabtools/vagrant.py
+++ b/fabtools/vagrant.py
@@ -5,7 +5,6 @@ Vagrant helpers
 from __future__ import with_statement
 
 from fabric.api import env, hide, local, settings, task
-import re
 
 
 def ssh_config(name=''):
@@ -30,7 +29,7 @@ def _settings_dict(config):
     port = config['Port']
 
     settings['host_string'] = "%s@%s:%s" % (user, hostname, port)
-    settings['key_filename'] = re.sub(r'^"|"$', '', config['IdentityFile']) # strip leading and trailing double quotes, if present
+    settings['key_filename'] = config['IdentityFile']).strip('"') # strip leading and trailing double quotes introduced by vagrant 1.1
     settings['forward_agent'] = (config.get('ForwardAgent', 'no') == 'yes')
     settings['disable_known_hosts'] = True
 


### PR DESCRIPTION
Vagrant `1.1` introduces leading and trailing whitespaces for IdentityFile when queried with `vagrant ssh-config`

this leads to

```
IOError: [Errno 2] No such file or directory: '"/Users/xyz/.vagrant.d/insecure_private_key"'
```

this patch removes the double quotes and keeps backward compatibility
