### PR TITLE
Fixing key_filename value from ssh-config

### DIFF
--- a/fabtools/vagrant.py
+++ b/fabtools/vagrant.py
@@ -29,7 +29,7 @@ def _settings_dict(config):
     port = config['Port']
 
     settings['host_string'] = "%s@%s:%s" % (user, hostname, port)
-    settings['key_filename'] = config['IdentityFile']
+    settings['key_filename'] = config['IdentityFile'].strip('"')
     settings['forward_agent'] = (config.get('ForwardAgent', 'no') == 'yes')
     settings['disable_known_hosts'] = True
 


### PR DESCRIPTION
In newer versions of Vagrant, the IdentityFile output from ssh-config
is surrounded by double quotes. This causes the key to not be found.
