### PR TITLE
Add git.fetch operation and use it in require.git.working_copy.

### DIFF
--- a/fabtools/git.py
+++ b/fabtools/git.py
@@ -51,6 +51,39 @@ def clone(remote_url, path=None, use_sudo=False, user=None):
         run(cmd)
 
 
+def fetch(path, use_sudo=False, user=None):
+    """ Fetch from a remote Git repository on an existing working copy.
+
+    :param path: Path of the working copy directory.  This directory must exist
+                 and be a Git working copy with a default remote to fetch from.
+    :type path: str
+
+    :param use_sudo: If ``True`` execute ``git`` with
+                     :func:`fabric.operations.sudo`, else with
+                     :func:`fabric.operations.run`.
+    :type use_sudo: bool
+
+    :param user: If ``use_sudo is True``, run :func:`fabric.operations.sudo`
+                 with the given user.  If ``use_sudo is False`` this parameter
+                 has no effect.
+    :type user: str
+    """
+
+    if path is None:
+        raise ValueError("Path to the working copy is needed to fetch from a "
+                         "remote repository.")
+
+    cmd = 'git fetch'
+
+    with cd(path):
+        if use_sudo and user is None:
+            run_as_root(cmd)
+        elif use_sudo:
+            sudo(cmd, user=user)
+        else:
+            run(cmd)
+
+
 def pull(path, use_sudo=False, user=None):
     """ Pull from a remote Git repository on an existing working copy.
 

--- a/fabtools/require/git.py
+++ b/fabtools/require/git.py
@@ -19,7 +19,7 @@ def working_copy(remote_url, path=None, branch="master", update=True,
     """
     Require a working copy of the repository from the ``remote_url``.
 
-    Clones or pulls from the repository under ``remote_url`` and checks out
+    Clones or fetchs from the repository under ``remote_url`` and checks out
     ``branch``.
 
     :param remote_url: URL of the remote repository (e.g.
@@ -31,16 +31,16 @@ def working_copy(remote_url, path=None, branch="master", update=True,
                  filesystem.  If this directory doesn't exist yet, a new
                  working copy is created through ``git clone``.  If the
                  directory does exist *and* ``update == True``, a
-                 ``git pull`` is issued.  If ``path is None`` the ``git clone``
-                 is issued in the current working directory and the directory
-                 name of the working copy is created by ``git``.
+                 ``git fetch`` is issued.  If ``path is None`` the
+                 ``git clone`` is issued in the current working directory and
+                 the directory name of the working copy is created by ``git``.
     :type path: str
 
-    :param branch: Branch to switch to after cloning or pulling.
+    :param branch: Branch to switch to after cloning or fetching.
     :type branch: str
 
     :param update: Whether or not to update an existing working copy via
-                   ``git pull``.
+                   ``git fetch``.
     :type update: bool
 
     :param use_sudo: If ``True`` execute ``git`` with
@@ -55,20 +55,20 @@ def working_copy(remote_url, path=None, branch="master", update=True,
     """
 
     if is_dir(path, use_sudo=use_sudo) and update:
-        # git pull
+        # git fetch
+        git.fetch(path=path, use_sudo=use_sudo, user=user)
+        git.checkout(path=path, branch=branch, use_sudo=use_sudo, user=user)
         git.pull(path=path, use_sudo=use_sudo, user=user)
 
     elif is_dir(path, use_sudo=use_sudo) and not update:
-        # do nothing
-        return
+        git.checkout(path=path, branch=branch, use_sudo=use_sudo, user=user)
 
     elif not is_dir(path, use_sudo=use_sudo):
         # git clone
         git.clone(remote_url, path=path, use_sudo=use_sudo, user=user)
         if path is None:
             path = remote_url.split('/')[-1].replace('.git', '')
+        git.checkout(path=path, branch=branch, use_sudo=use_sudo, user=user)
 
     else:
         raise ValueError("Invalid combination of parameters.")
-
-    git.checkout(path=path, branch=branch, use_sudo=use_sudo, user=user)


### PR DESCRIPTION
`require.git.working_copy` currently doesn't do what's expected when the working copy already exists _and_ shall be updated _and_ a different branch shall be checked out.  To support this use case the `git.fetch` operation has been added and is used in `require.git.working_copy`.
