### PR TITLE
Uses `SHOW DATABASES` to test existent of database.

### DIFF
--- a/fabtools/mysql.py
+++ b/fabtools/mysql.py
@@ -80,7 +80,7 @@ def database_exists(name, **kwargs):
     Check if a MySQL database exists.
     """
     with settings(hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
-        res = _query("use mysql; SELECT Db FROM db WHERE Db = '%(name)s';" % {
+        res = _query("SHOW DATABASES LIKE '%(name)s';" % {
             'name': name
         }, **kwargs)
 


### PR DESCRIPTION
The `mysql.user` and `mysql.db` table is used for access privilege.
see http://dev.mysql.com/doc/refman/5.5/en/grant-table-structure.html

A database owned by root may not exists in the `mysql.db` table. So `mysql.database_exists` function may fails if the database is owned by root user.

Use `SHOW DATABASES` instead of `SELECT Db FROM mysql.db`
avoid the problem.
