### PR TITLE
Installing distribute should not be hard coded to run as root.

### DIFF
--- a/fabtools/python_distribute.py
+++ b/fabtools/python_distribute.py
@@ -42,7 +42,7 @@ def install_distribute():
     """
     with cd("/tmp"):
         run("curl --silent -O http://python-distribute.org/distribute_setup.py")
-        run_as_root("python distribute_setup.py")
+        run("python distribute_setup.py")
 
 
 def install(packages, upgrade=False, use_sudo=False):


### PR DESCRIPTION
Do run() instead of run_as_root() so user can decide context using
a with statement such as:

with fabtools.python.virtualenv('/home/example/python'):
  fabtools.require.python.distribute()
