### PR TITLE
Fix run as postgres

### DIFF
--- a/fabtools/postgres.py
+++ b/fabtools/postgres.py
@@ -7,7 +7,7 @@ This module provides tools for creating PostgreSQL users and databases.
 """
 from __future__ import with_statement
 
-from fabric.api import cd, hide, settings, sudo
+from fabric.api import cd, hide, run, settings
 
 
 def _run_as_pg(command):
@@ -15,7 +15,7 @@ def _run_as_pg(command):
     Run command as 'postgres' user
     """
     with cd('/var/lib/postgresql'):
-        return sudo('sudo -u postgres %s' % command)
+        return run('sudo -u postgres %s' % command)
 
 
 def user_exists(name):


### PR DESCRIPTION
Changing to sudo(command, user='postgres') does not work as the directory change is run in the sudo which fails.
run('sudo -u postgres %s' % command) results in cd /var/lib/postgresql && sudo -u postgres COMMAND
sudo(command, user='postgres') results in sudo -u postgres cd /var/lib/postgresql && COMMAND
The use case is a sudoer given NOPASSWD for postgres running psql.
