### PR TITLE
Fix redis module DB persistency issue

### DIFF
--- a/fabtools/require/redis.py
+++ b/fabtools/require/redis.py
@@ -127,7 +127,8 @@ def instance(name, version=VERSION, **kwargs):
     params.setdefault('port', '6379')
     params.setdefault('logfile', '/var/log/redis/redis-%(name)s.log' % locals())
     params.setdefault('loglevel', 'verbose')
-    params.setdefault('dbfilename', '/var/db/redis/redis-%(name)s-dump.rdb' % locals())
+    params.setdefault('dir', '/var/db/redis')
+    params.setdefault('dbfilename', 'redis-%(name)s-dump.rdb' % locals())
     params.setdefault('save', ['900 1', '300 10', '60 10000'])
 
     # Build config file from parameters


### PR DESCRIPTION
`dir` config var should be set, and all data is relative to it.
- CF http://redis.io/topics/quickstart
- CF https://github.com/antirez/redis/issues/305
