### PR TITLE
Allow specific version of Debian package

### DIFF
--- a/fabtools/deb.py
+++ b/fabtools/deb.py
@@ -50,7 +50,7 @@ def is_installed(pkg_name):
         return False
 
 
-def install(packages, update=False, options=None):
+def install(packages, update=False, options=None, version=None):
     """
     Install one or more packages.
 
@@ -78,12 +78,16 @@ def install(packages, update=False, options=None):
         update_index()
     if options is None:
         options = []
+    if version is None:
+        version = ''
+    if version and not isinstance(packages, list):
+        version = '=' + version
     if not isinstance(packages, basestring):
         packages = " ".join(packages)
     options.append("--quiet")
     options.append("--assume-yes")
     options = " ".join(options)
-    cmd = '%(manager)s install %(options)s %(packages)s' % locals()
+    cmd = '%(manager)s install %(options)s %(packages)s%(version)s' % locals()
     run_as_root(cmd, pty=False)
 
 

--- a/fabtools/require/deb.py
+++ b/fabtools/require/deb.py
@@ -70,7 +70,7 @@ def ppa(name):
         update_index()
 
 
-def package(pkg_name, update=False):
+def package(pkg_name, update=False, version=None):
     """
     Require a deb package to be installed.
 
@@ -81,7 +81,7 @@ def package(pkg_name, update=False):
         require.deb.package('foo')
     """
     if not is_installed(pkg_name):
-        install(pkg_name, update)
+        install(pkg_name, update=update, version=version)
 
 
 def packages(pkg_list, update=False):


### PR DESCRIPTION
Hey @ronnix,

This PR allows `require.package` (as well as `deb.install`) to specify a version, for ex:

```
def install_specific_packages():
    require.deb.package('firefox', version='11.0+build1-0ubuntu4')
    deb.install('emacs', version='23.3+1-1ubuntu9')
```

The test case was for Selenium that doesn't play well with newer versions of Firefox.

Merci! :fr: 

@cgphillips contributed to this PR as well
