### PR TITLE
FIX: rpm.install doesn't work due to not using pty

### DIFF
--- a/fabtools/rpm.py
+++ b/fabtools/rpm.py
@@ -108,9 +108,9 @@ def install(packages, repos=None, yes=None, options=None):
             options.append('--enablerepo=%(repo)s' % locals())
     options = " ".join(options)
     if isinstance(yes, str):
-        run_as_root('yes %(yes)s | %(manager)s %(options)s install %(packages)s' % locals(), pty=False)
+        run_as_root('yes %(yes)s | %(manager)s %(options)s install %(packages)s' % locals())
     else:
-        run_as_root('%(manager)s %(options)s install %(packages)s' % locals(), pty=False)
+        run_as_root('%(manager)s %(options)s install %(packages)s' % locals())
 
 
 def groupinstall(group, options=None):


### PR DESCRIPTION
As I wrote in [this comment](https://github.com/ronnix/fabtools/commit/4250c38118847447153477311af6416a9a0119d8#commitcomment-3291516), pty=False breaks rpm.install() command.
This patch will fix the issue.
