### PR TITLE
PyPI is now behind a CDN, pip --use-mirrors should default to False

### DIFF
--- a/fabtools/python.py
+++ b/fabtools/python.py
@@ -75,7 +75,7 @@ def is_installed(package):
     return (package in packages)
 
 
-def install(packages, upgrade=False, use_mirrors=True, use_sudo=False,
+def install(packages, upgrade=False, use_mirrors=False, use_sudo=False,
             user=None, download_cache=None, quiet=False):
     """
     Install Python package(s) using `pip`_.
@@ -112,7 +112,7 @@ def install(packages, upgrade=False, use_mirrors=True, use_sudo=False,
         run(command, pty=False)
 
 
-def install_requirements(filename, upgrade=False, use_mirrors=True,
+def install_requirements(filename, upgrade=False, use_mirrors=False,
                          use_sudo=False, user=None, download_cache=None,
                          quiet=False):
     """


### PR DESCRIPTION
PyPI is now behind a CDN and should get a lot faster then using mirrors: http://mail.python.org/pipermail/distutils-sig/2013-May/020848.html
