### PR TITLE
Fix md5sum to work on recent SmartOS,

### DIFF
--- a/fabtools/files.py
+++ b/fabtools/files.py
@@ -114,7 +114,8 @@ def md5sum(filename, use_sudo=False):
     Compute the MD5 sum of a file.
     """
     func = use_sudo and run_as_root or run
-    with settings(hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
+    with settings(hide('running', 'stdout', 'stderr', 'warnings'),
+                  warn_only=True):
         # Linux (LSB)
         if exists(u'/usr/bin/md5sum'):
             res = func(u'/usr/bin/md5sum %(filename)s' % locals())
@@ -124,8 +125,20 @@ def md5sum(filename, use_sudo=False):
         # SmartOS Joyent build
         elif exists(u'/opt/local/gnu/bin/md5sum'):
             res = func(u'/opt/local/gnu/bin/md5sum %(filename)s' % locals())
+        # SmartOS Joyent build
+        # (the former doesn't exist, at least on joyent_20130222T000747Z)
+        elif exists(u'/opt/local/bin/md5sum'):
+            res = func(u'/opt/local/bin/md5sum %(filename)s' % locals())
+        # Try to find ``md5sum`` or ``md5`` on ``$PATH`` or abort
         else:
-            abort('No MD5 utility was found on this system.')
+            md5sum = func(u'which md5sum')
+            md5 = func(u'which md5')
+            if exists(md5sum):
+                res = func('%(md5sum)s %(filename)s' % locals())
+            elif exists(md5):
+                res = func('%(md5)s %(filename)s' % locals())
+            else:
+                abort('No MD5 utility was found on this system.')
 
     if res.succeeded:
         parts = res.split()


### PR DESCRIPTION
also add fallback to look for `md5sum` or `md5` in `$PATH` if everything else fails.
