### PR TITLE
Support tags in addition to branches with ``fabtools.require.git.working_copy``

### DIFF
--- a/fabtools/require/git.py
+++ b/fabtools/require/git.py
@@ -76,7 +76,9 @@ def working_copy(remote_url, path=None, branch="master", update=True,
                  the directory name of the working copy is created by ``git``.
     :type path: str
 
-    :param branch: Branch to check out.
+    :param branch: Branch or tag to check out.  If the given value is a tag
+                   name, update must be ``False`` or consecutive calls will
+                   fail.
     :type branch: str
 
     :param update: Whether or not to fetch and merge remote changesets.


### PR DESCRIPTION
This change allows to pass tag names with the branch parameter, which previously failed if the tag didn't yet exist in the working copy.  Now the `fetch` and `checkout` operations are always executed, and only `pull` depends on `update` being `True`.
