### PR TITLE
Fix bug in pkg.is_installed with certain package names

### DIFF
--- a/fabtools/pkg.py
+++ b/fabtools/pkg.py
@@ -23,10 +23,11 @@ def update_index(force=False):
     manager = MANAGER
     if force:
         with quiet():
-            run_as_root("%(manager)s cl" % locals())
-        run_as_root("%(manager)s -f up" % locals())
+            # clean the package cache
+            run_as_root("%(manager)s clean" % locals())
+        run_as_root("%(manager)s -f update" % locals())
     else:
-        run_as_root("%(manager)s up" % locals())
+        run_as_root("%(manager)s update" % locals())
 
 
 def upgrade(full=False):
@@ -34,7 +35,7 @@ def upgrade(full=False):
     Upgrade all packages.
     """
     manager = MANAGER
-    cmds = {'pkgin': {False: 'ug', True: 'fug'}}
+    cmds = {'pkgin': {False: 'uprade', True: 'full-upgrade'}}
     cmd = cmds[manager][full]
     run_as_root("%(manager)s -y %(cmd)s" % locals())
 
@@ -85,9 +86,9 @@ def install(packages, update=False, yes=None, options=None):
     options.append("-y")
     options = " ".join(options)
     if isinstance(yes, str):
-        run_as_root('yes %(yes)s | %(manager)s %(options)s in %(packages)s' % locals())
+        run_as_root('yes %(yes)s | %(manager)s %(options)s install %(packages)s' % locals())
     else:
-        run_as_root('%(manager)s %(options)s in %(packages)s' % locals())
+        run_as_root('%(manager)s %(options)s install %(packages)s' % locals())
 
 
 def uninstall(packages, orphan=False, options=None):
@@ -109,7 +110,7 @@ def uninstall(packages, orphan=False, options=None):
     options.append("-y")
     options = " ".join(options)
     if orphan:
-        run_as_root('%(manager)s -y ar' % locals())
+        run_as_root('%(manager)s -y autoremove' % locals())
     run_as_root('%(manager)s %(options)s remove %(packages)s' % locals())
 
 


### PR DESCRIPTION
The current implementation fails under these conditions:
- the queried package name is part of another package name and
- the other package is already installed

Example:

`pkg.is_installed('gcc47')` returns `True` when it's not installed, but `gcc47-libs` is.

The fix provides an implementation that uses `pkg_info` to query exact package names instead of grepping through the list of installed packages.
