### PR TITLE
Update Oracle JDK default version to 7u25-b15

### DIFF
--- a/fabtools/oracle_jdk.py
+++ b/fabtools/oracle_jdk.py
@@ -17,7 +17,7 @@ from fabtools.files import is_link
 from fabtools.system import get_arch
 
 
-DEFAULT_VERSION = '7u21-b11'
+DEFAULT_VERSION = '7u25-b15'
 
 
 def install_from_oracle_site(version=DEFAULT_VERSION):


### PR DESCRIPTION
I had trouble downloading the current default version of JDK from Oracle website today. Updating to the latest version solved the issue.
