### PR TITLE
Add require.deb.key and update deb.add_apt_key.

### DIFF
--- a/fabtools/tests/fabfiles/deb.py
+++ b/fabtools/tests/fabfiles/deb.py
@@ -1,0 +1,80 @@
+from __future__ import with_statement
+
+from fabric.api import (
+    shell_env,
+    task,
+)
+
+
+def reset():
+    from fabric.api import settings
+    from fabtools.utils import run_as_root
+
+    with settings(warn_only=True):
+        run_as_root('apt-key del 7BD9BF62')
+        run_as_root('apt-key del C4DEFFEB')
+
+@task
+def deb():
+    """
+    Check deb functions.
+    """
+
+    from fabric.api import run
+    from fabtools import require
+    from fabtools import deb
+
+    # deb.add_apt_key with keyid
+    reset()
+    deb.add_apt_key(keyid='C4DEFFEB', url='http://repo.varnish-cache.org/debian/GPG-key.txt')
+    run('apt-key finger | grep -q C4DEFFEB')
+
+    reset()
+    deb.add_apt_key(keyid='7BD9BF62')
+    deb.add_apt_key(keyid='7BD9BF62') # Intentionally repeated
+    run('apt-key finger | grep -q 7BD9BF62')
+
+    reset()
+    deb.add_apt_key(keyid='7BD9BF62', keyserver='keyserver.ubuntu.com')
+    run('apt-key finger | grep -q 7BD9BF62')
+
+    reset()
+    run('wget http://repo.varnish-cache.org/debian/GPG-key.txt -O /tmp/tmp.fabtools.test.key')
+    deb.add_apt_key(keyid='C4DEFFEB', filename='/tmp/tmp.fabtools.test.key')
+    run('apt-key finger | grep -q C4DEFFEB')
+
+
+    # deb.add_apt_key without keyid
+    reset()
+    deb.add_apt_key(url='http://repo.varnish-cache.org/debian/GPG-key.txt')
+    run('apt-key finger | grep -q C4DEFFEB')
+
+    reset()
+    deb.add_apt_key(keyid='7BD9BF62')
+    run('apt-key finger | grep -q 7BD9BF62')
+
+    reset()
+    run('wget http://repo.varnish-cache.org/debian/GPG-key.txt -O /tmp/tmp.fabtools.test.key')
+    deb.add_apt_key(filename='/tmp/tmp.fabtools.test.key')
+    run('apt-key finger | grep -q C4DEFFEB')
+
+    # require.deb.key
+    reset()
+    require.deb.key(keyid='C4DEFFEB', url='http://repo.varnish-cache.org/debian/GPG-key.txt')
+    run('apt-key finger | grep -q C4DEFFEB')
+
+    reset()
+    require.deb.key(keyid='7BD9BF62')
+    require.deb.key(keyid='7BD9BF62') # Intentionally repeated
+    run('apt-key finger | grep -q 7BD9BF62')
+
+    reset()
+    require.deb.key(keyid='7BD9BF62', keyserver='keyserver.ubuntu.com')
+    run('apt-key finger | grep -q 7BD9BF62')
+
+    reset()
+    run('wget http://repo.varnish-cache.org/debian/GPG-key.txt -O /tmp/tmp.fabtools.test.key')
+    require.deb.key(keyid='C4DEFFEB', filename='/tmp/tmp.fabtools.test.key')
+    run('apt-key finger | grep -q C4DEFFEB')
+
+


### PR DESCRIPTION
Now deb.add_apt_key can import keys from a keyserver
and check fingerprints. update is False.

require.deb.key adds a require-style interface for
add_apt_key.
