### PR TITLE
service.is_running

### DIFF
--- a/fabtools/service.py
+++ b/fabtools/service.py
@@ -28,8 +28,12 @@ def is_running(service):
             print "Service foo is running!"
     """
     with settings(hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
-        res = run_as_root('service %(service)s status' % locals())
-        return res.succeeded
+        test_upstart = run_as_root('test -f /etc/init/{}.conf'.format(service))
+        status = run_as_root('service %(service)s status' % locals())
+        if test_upstart.succeeded:
+            return 'running' in status
+        else:
+            return status.succeeded
 
 
 def start(service):


### PR DESCRIPTION
Update is_running to actual return whether or not a service is running.
The status command succeedes no matter if the service is running or not.
This has is_running check for the presence of 'running' in the output of
`service <service> status`.

service.is_running currently just checks to see whether the call to `service <service> status` succeeds. This is not enough to determine whether the service is running or not.
