### PR TITLE
run_guest_command fails because of extra kwargs

### DIFF
--- a/fabtools/openvz/contextmanager.py
+++ b/fabtools/openvz/contextmanager.py
@@ -68,7 +68,7 @@ def guest(name_or_ctid):
 
     def run_guest_command(command, shell=True, pty=True, combine_stderr=True,
         sudo=False, user=None, quiet=False, warn_only=False, stdout=None,
-        stderr=None, group=None, timeout=None):
+        stderr=None, group=None, timeout=None,**kwargs):
         """
         Run command inside a guest container
         """


### PR DESCRIPTION
I had to append "**kwargs" to the run_guest_command function in openvz/contextmanager.py in order to execute guest commands with fabric 1.7.  From looking at that file it doesn't look like it would cause any issues.
