### PR TITLE
fixed bug where services would appear to start, but would actually still be stopped

### DIFF
--- a/fabtools/service.py
+++ b/fabtools/service.py
@@ -44,7 +44,7 @@ def start(service):
         if not fabtools.service.is_running('foo'):
             fabtools.service.start('foo')
     """
-    run_as_root('service %(service)s start' % locals())
+    run_as_root('service %(service)s start' % locals(), pty=False)
 
 
 def stop(service):
@@ -76,7 +76,7 @@ def restart(service):
         else:
             fabtools.service.start('foo')
     """
-    run_as_root('service %(service)s restart' % locals())
+    run_as_root('service %(service)s restart' % locals(), pty=False)
 
 
 def reload(service):
@@ -94,7 +94,7 @@ def reload(service):
 
         The service needs to support the ``reload`` operation.
     """
-    run_as_root('service %(service)s reload' % locals())
+    run_as_root('service %(service)s reload' % locals(), pty=False)
 
 
 def force_reload(service):
@@ -112,4 +112,4 @@ def force_reload(service):
 
         The service needs to support the ``force-reload`` operation.
     """
-    run_as_root('service %(service)s force-reload' % locals())
+    run_as_root('service %(service)s force-reload' % locals(), pty=False)


### PR DESCRIPTION
Without setting pty=False, some services will print the standard start response:

```
[servername] out: sudo password: * Starting web server apache2
[servername] out:    ...done.
```

However, the service will not actually be restarted. Stopping appears to work without pty=False.

Tested with the apache2 service on Ubuntu 12.04.

See http://stackoverflow.com/questions/6379484/fabric-appears-to-start-apache2-but-doesnt for more info.
