### PR TITLE
Add the ability to specify Nginx-extras for require.nginx.server

### DIFF
--- a/fabtools/require/nginx.py
+++ b/fabtools/require/nginx.py
@@ -16,6 +16,7 @@ from fabric.api import (
     settings,
 )
 from fabric.colors import red
+from fabtools.deb import is_installed
 
 from fabtools.files import is_link
 from fabtools.nginx import disable, enable
@@ -88,7 +89,8 @@ def site(server_name, template_contents=None, template_source=None,
 
     .. seealso:: :py:func:`fabtools.require.files.template_file`
     """
-    server()
+    if not is_installed('nginx-common'):  # nginx-common is always installed if Nginx exists
+        server()
 
     config_filename = '/etc/nginx/sites-available/%s.conf' % server_name
 


### PR DESCRIPTION
We're using fabtools require to install Nginx for our systems, but we use extra modules only found in nginx-extras, adding this allows us to specify that we want nginx-extras and use similar syntax to everyone else
