### PR TITLE
Fix working copy path, rstrip takes an alphabet to strip

### DIFF
--- a/fabtools/require/git.py
+++ b/fabtools/require/git.py
@@ -99,7 +99,9 @@ def working_copy(remote_url, path=None, branch="master", update=True,
     command()
 
     if path is None:
-        path = remote_url.split('/')[-1].rstrip('.git')
+        path = remote_url.split('/')[-1]
+        if path.endswith('.git'):
+            path = path[:-4]
 
     if is_dir(path, use_sudo=use_sudo) and update:
         git.fetch(path=path, use_sudo=use_sudo, user=user)


### PR DESCRIPTION
Fix working copy path, rstrip takes and alphabet to strip, not a string used in whole.

Consider the repo ttttttt, rstrip reduces this to the empty string.
