### PR TITLE
vagrant task documentation appeared twice

### DIFF
--- a/docs/api/vagrant.rst
+++ b/docs/api/vagrant.rst
@@ -5,5 +5,3 @@
 
 .. automodule:: fabtools.vagrant
     :members:
-
-    .. autofunction:: vagrant


### PR DESCRIPTION
Super minor, but I happened to see this as I was browsing the [live vagrant documentation](http://fabtools.readthedocs.org/en/0.16.0/api/vagrant.html), which currently lists documentation for fabtools.vagrant.vagrant twice.
