### PR TITLE
use env.host_string if no 'name' is specified with vagrant

### DIFF
--- a/fabtools/vagrant.py
+++ b/fabtools/vagrant.py
@@ -6,11 +6,20 @@ from __future__ import with_statement
 
 from fabric.api import env, hide, local, settings, task
 
+# if name is specified, use that. otherwise try to use env.host_string
+# if it exists
+def _name_or_host_string(name):
+    return name or (env.host_string or name)
 
 def ssh_config(name=''):
     """
-    Get the SSH parameters for connecting to a vagrant VM.
+    Get the SSH parameters for connecting to a vagrant VM named `name`. 
+
+    If `name` is empty, this tries to infer the correct name from
+    `env.host_string` so that you can retrieve the vagrant ssh
+    configuration on the currently specified `env.host_string`.
     """
+    name = _name_or_host_string(name)
     with settings(hide('running')):
         output = local('vagrant ssh-config %s' % name, capture=True)
 
@@ -46,8 +55,7 @@ def _settings_dict(config):
 
 @task
 def vagrant(name=''):
-    """
-    Run the following tasks on a vagrant box.
+    """Run the following tasks on a vagrant box.
 
     First, you need to import this task in your ``fabfile.py``::
 
@@ -61,7 +69,6 @@ def vagrant(name=''):
     Then you can easily run tasks on your current Vagrant box::
 
         $ fab vagrant some_task
-
     """
     config = ssh_config(name)
 
@@ -71,7 +78,7 @@ def vagrant(name=''):
 
 def vagrant_settings(name='', *args, **kwargs):
     """
-    Context manager that sets a vagrant VM
+    Context manager that sets a vagrant VM named `name`
     as the remote host.
 
     Use this context manager inside a task to run commands
@@ -81,7 +88,12 @@ def vagrant_settings(name='', *args, **kwargs):
 
         with vagrant_settings():
             run('hostname')
+
+    If `name` is empty, this tries to infer the correct name from
+    `env.host_string` so that you can use this context manager on the
+    currently specified `host_string`.
     """
+    name = _name_or_host_string(name)
     config = ssh_config(name)
 
     extra_args = _settings_dict(config)


### PR DESCRIPTION
The idea is to provide better support for multi-vagrant + fabric + fabtools usage patterns like `fab production packages` where the corresponding fabfile.py might look something like this:

``` python
@task
def production():
    env.hosts = ['vagrant_box_1', 'vagrant_box_2', 'vagrant_box_3']

@task
def packages():
    with vagrant_settings():
        fabtools.require.python.packages(["nltk", "scikit-learn"])
```

I think this makes it slightly easier to manage multi-machine vagrant setups. 

If this is something that gets incorporated, I'd be happy to update #202 to also use the `_name_or_host_string` function in a similar way.

Please note that I wasn't exactly sure how this should affect the behavior of the `vagrant` task. Depending on what happens with #177, I could imagine incorporating a similar type of behavior using `_name_or_host_string` there, too, but its not exactly clear what the best usage pattern would be in that case.

I didn't add any tests for this as I wasn't exactly sure where to get started. I'd be happy to do whatever's necessary to get this merged in as its something that would make my fabfile's considerably simpler :)
