### PR TITLE
Fix KeyError in nodejs.package_version when no package is installed

### DIFF
--- a/fabtools/nodejs.py
+++ b/fabtools/nodejs.py
@@ -156,7 +156,7 @@ def package_version(package, local=False, npm='npm'):
     with hide('running', 'stdout'):
         res = run('%(npm)s list %(options)s' % locals())
 
-    dependencies = json.loads(res)['dependencies']
+    dependencies = json.loads(res).get('dependencies', {})
     pkg_data = dependencies.get(package)
     if pkg_data:
         return pkg_data['version']


### PR DESCRIPTION
`npm list` returns an empty dict when no packages is installed and `nodejs.package_version` was expecting a key from this empty dictionary.
