### PR TITLE
fabtools.python.virtualenv: pass the local flag to abspath

### DIFF
--- a/fabtools/python.py
+++ b/fabtools/python.py
@@ -273,7 +273,7 @@ def virtualenv(directory, local=False):
     path_mod = os.path if local else posixpath
 
     # Build absolute path to the virtualenv activation script
-    venv_path = abspath(directory)
+    venv_path = abspath(directory, local)
     activate_path = path_mod.join(venv_path, 'bin', 'activate')
 
     # Source the activation script


### PR DESCRIPTION
This commit ensures that the call to abspath looks for the absolute path
of the local virtualenv instead of attempting to connect to a remote
host when local is True.
