### PR TITLE
lsb_release returns Arch instead of Archlinux

### DIFF
--- a/fabtools/system.py
+++ b/fabtools/system.py
@@ -150,7 +150,7 @@ def distrib_family():
         return 'sun'
     elif distrib in ['Gentoo']:
         return 'gentoo'
-    elif distrib in ['Archlinux']:
+    elif distrib in ['Archlinux', 'Arch']:
         return 'arch'
     else:
         return 'other'


### PR DESCRIPTION
This fixes distrib_family() returning 'other' instead of 'arch'.
