### PR TITLE
Arch bundles headers with base package

### DIFF
--- a/fabtools/require/python.py
+++ b/fabtools/require/python.py
@@ -50,6 +50,8 @@ def setuptools(version=MIN_SETUPTOOLS_VERSION, python_cmd='python'):
             require_deb_package('python-dev')
         elif family == 'redhat':
             require_rpm_package('python-devel')
+        elif family == 'arch':
+            pass # ArchLinux installs header with base package
         else:
             raise UnsupportedFamily(supported=['debian', 'redhat'])
 


### PR DESCRIPTION
require/python.setuptools() doesn't need to raise when running arch linux.
