### PR TITLE
add Elementary OS (Ubuntu based Distro) to the Debian Family list

### DIFF
--- a/fabtools/system.py
+++ b/fabtools/system.py
@@ -142,7 +142,7 @@ def distrib_family():
     ``sun``, ``other``.
     """
     distrib = distrib_id()
-    if distrib in ['Debian', 'Ubuntu', 'LinuxMint']:
+    if distrib in ['Debian', 'Ubuntu', 'LinuxMint', 'elementary OS']:
         return 'debian'
     elif distrib in ['RHEL', 'CentOS', 'SLES', 'Fedora']:
         return 'redhat'


### PR DESCRIPTION
Hi ronnix, 
I added Elementary OS (based on ubuntu 12.04) to the Debian Family List. 
the `elementary OS` string is the result of `lsb_release --id --short`, which is indeed available on this distrib.
