### PR TITLE
apt_key_exists doesn't work properly

### DIFF
--- a/fabtools/deb.py
+++ b/fabtools/deb.py
@@ -154,10 +154,20 @@ def get_selections():
     return selections
 
 
+def _validate_apt_key(keyid):
+    instructions = (
+        "\nTo find the keyid for a apt key, try running the following command:\n\n"
+        r"    gpg --with-colons /path/to/file.key | cut -d: -f5 | sed 's/.*\(.\{8\}\)$/\1/'"
+    )
+    if len(keyid) != 8:
+        raise ValueError('keyid should be an 8-character string, not "%(keyid)s" %(instructions)s"' % locals())
+
+
 def apt_key_exists(keyid):
     """
     Check if the given key id exists in apt keyring.
     """
+    _validate_apt_key(keyid)
 
     # Command extracted from apt-key source
     gpg_cmd = 'gpg --ignore-time-conflict --no-options --no-default-keyring --keyring /etc/apt/trusted.gpg'
@@ -202,6 +212,7 @@ def add_apt_key(filename=None, url=None, keyid=None, keyserver='subkeys.pgp.net'
         else:
             raise ValueError('Either filename, url or keyid must be provided as argument')
     else:
+        _validate_apt_key(keyid)
         if filename is not None:
             _check_pgp_key(filename, keyid)
             run_as_root('apt-key add %(filename)s' % locals())

--- a/fabtools/tests/test_deb.py
+++ b/fabtools/tests/test_deb.py
@@ -1,0 +1,13 @@
+import unittest
+
+from mock import patch
+
+
+class AptKeyTestCase(unittest.TestCase):
+
+    def test_key_length(self):
+        from fabtools.deb import _validate_apt_key
+
+        self.assertRaises(ValueError, _validate_apt_key, "ABC123")
+        self.assertRaises(ValueError, _validate_apt_key, "ABCDE12345")
+        self.assertEqual(_validate_apt_key("ABCD1234"), None)


### PR DESCRIPTION
The fabtools.deb.apt_key_exists function only checks for keys matching in `/etc/apt/trusted.gpg`, but when you run fabtools.deb.add_apt_key with this `postgres` key on Ubuntu 12.04 it is actually installed in `/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg`. As a result, this code snippet ends up downloading and reinstalling the apt key every time this it is run.

``` python
if not fabtools.deb.apt_key_exists('7FCC7D46ACCC4CF8'):
    fabtools.deb.add_apt_key(
        url='https://www.postgresql.org/media/keys/ACCC4CF8.asc',
        keyid='7FCC7D46ACCC4CF8',
     )
fabtools.require.deb.source('postgresql',
                            'http://apt.postgresql.org/pub/repos/apt/',
                            'precise-pgdg',
                            'main')
```

Might be nice to generalize this a bit by having a `fabtools.require.deb.apt_key` function.
