### PR TITLE
Add support for conda package manager

### DIFF
--- a/fabtools/__init__.py
+++ b/fabtools/__init__.py
@@ -1,5 +1,6 @@
 # Keep imports sorted alphabetically
 import fabtools.arch
+import fabtools.conda
 import fabtools.cron
 import fabtools.deb
 import fabtools.disk

--- a/fabtools/conda.py
+++ b/fabtools/conda.py
@@ -1,0 +1,55 @@
+"""
+Conda packages
+===============
+
+This module provides tools for installing conda packages using
+the `miniconda`_ distribution.
+
+.. _miniconda: http://conda.pydata.org/miniconda.html
+
+"""
+
+from fabric.api import cd, run, settings, hide
+from fabric.contrib import files
+
+from fabtools.utils import download, run_as_root
+
+
+MINICONDA_URL = 'http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh'
+
+def install_miniconda(python_cmd='python', use_sudo=True, prefix='~/miniconda'):
+    """
+    Install the latest version of `miniconda`_.
+
+    :param prefix: prefix for the miniconda installation
+
+    ::
+
+        import fabtools
+
+        fabtools.conda.install_miniconda()
+
+    """
+
+    with cd("/tmp"):
+        download(MINICONDA_URL)
+
+        command = 'bash Miniconda-latest-Linux-x86_64.sh -b -p %(prefix)s' % locals()
+        if use_sudo:
+            run_as_root(command)
+        else:
+            run(command)
+        files.append('~/.bash_profile', 'export PATH=%(prefix)s/bin:$PATH' % locals())
+
+        run('rm -f Miniconda-latest-Linux-x86_64.sh')
+
+def is_conda_installed():
+    """
+    Check if `conda` is installed.
+
+    """
+    with settings(hide('running', 'warnings', 'stderr', 'stdout'), warn_only=True):
+        res = run('conda -V 2>/dev/null')
+        if res.failed:
+            return False
+        return res.succeeded

--- a/fabtools/conda.py
+++ b/fabtools/conda.py
@@ -8,9 +8,14 @@ the `miniconda`_ distribution.
 .. _miniconda: http://conda.pydata.org/miniconda.html
 
 """
+from pipes import quote
+import os
 
 from fabric.api import cd, run, settings, hide
 from fabric.contrib import files
+from fabric.operations import sudo
+from fabric.utils import puts
+from fabtools import utils
 
 from fabtools.utils import download, run_as_root
 
@@ -34,6 +39,7 @@ def install_miniconda(python_cmd='python', use_sudo=True, prefix='~/miniconda'):
     with cd("/tmp"):
         download(MINICONDA_URL)
 
+        prefix = utils.abspath(prefix)
         command = 'bash Miniconda-latest-Linux-x86_64.sh -b -p %(prefix)s' % locals()
         if use_sudo:
             run_as_root(command)
@@ -53,3 +59,109 @@ def is_conda_installed():
         if res.failed:
             return False
         return res.succeeded
+
+
+def create_env(name=None, prefix=None, yes=True, override_channels=False,
+               channels=None, packages=None, use_sudo=False, user=None,
+               quiet=True):
+    """
+    Create a conda environment.
+
+    :param name: name of environment (in conda environment directory)
+    :param prefix: full path to environment prefix
+    :param yes: do not ask for confirmation
+    :param quiet: do not display progress bar
+    :param override_channels: Do not search default or .condarc channels. Requires `channels` .True or False
+    :param channels: additional channel to search for packages. These are
+                        URLs searched in the order they are given (including
+                        file:// for local directories). Then, the defaults or
+                        channels from .condarc are searched (unless
+                        `override-channels` is given). You can use 'defaults'
+                        to get the default packages for conda, and 'system' to
+                        get the system packages, which also takes .condarc
+                        into account. You can also use any name and the
+                        .condarc channel_alias value will be prepended. The
+                        default channel_alias is http://conda.binstar.org/
+    :param packages: package versions to install into conda environment
+    :param use_sudo: Use sudo
+    :param user: sudo user
+    ::
+
+        import fabtools
+
+        fabtools.conda.create_(path='/path/to/venv')
+    """
+    options = []
+    if override_channels:
+        options.append('--override_channels')
+    if name:
+        options.append('--name ' + quote(name))
+    if prefix:
+        options.append('--prefix ' + quote(utils.abspath(prefix)))
+    if yes:
+        options.append('--yes')
+    if quiet:
+        options.append('--quiet')
+    for ch in channels or []:
+        options.append('-c ' + quote(ch))
+    options.extend(packages or ['python'])
+
+    options = ' '.join(options)
+
+
+    command = 'conda create ' + options
+    if use_sudo:
+        sudo(command, user=user)
+    else:
+        run(command)
+
+
+def env_exists(name=None, prefix=None):
+    """
+    Check if a conda environment exists.
+    """
+    if not prefix:  # search in default env dir
+        command = "conda info -e | grep -e '^%(name)s\s'" % locals()
+        return run(command, shell_escape=False).succeeded
+    else:
+        # check if just a prefix or prefix & name are given:
+        if name:
+            base = prefix
+        else:
+            # we were given a full path to the environment.
+            # we split this up into the parent directory + the environment path
+            # so we can call 'conda info' with CONDA_ENVS_PATH set to the
+            # parent dir
+            prefix = utils.abspath(prefix)
+            base, name = prefix, ''
+            while name == '':
+                base, name = os.path.split(base)
+        command = "CONDA_ENVS_PATH=%(base)s conda info -e | grep -e '^%(name)s\s'" % locals()
+        return run(command, shell_escape=False).succeeded
+
+#
+# @contextmanager
+# def env(directory, local=False):
+#     """
+#     Context manager to activate an existing Python `virtual environment`_.
+#
+#     ::
+#
+#         from fabric.api import run
+#         from fabtools.python import virtualenv
+#
+#         with virtualenv('/path/to/virtualenv'):
+#             run('python -V')
+#
+#     .. _virtual environment: http://www.virtualenv.org/
+#     """
+#
+#     path_mod = os.path if local else posixpath
+#
+#     # Build absolute path to the virtualenv activation script
+#     venv_path = abspath(directory, local)
+#     activate_path = path_mod.join(venv_path, 'bin', 'activate')
+#
+#     # Source the activation script
+#     with prefix('. %s' % quote(activate_path)):
+#         yield

--- a/fabtools/require/__init__.py
+++ b/fabtools/require/__init__.py
@@ -1,6 +1,7 @@
 # Keep imports sorted alphabetically
 import fabtools.require.arch
 import fabtools.require.apache
+import fabtools.require.conda
 import fabtools.require.curl
 import fabtools.require.deb
 import fabtools.require.files

--- a/fabtools/require/conda.py
+++ b/fabtools/require/conda.py
@@ -1,0 +1,68 @@
+"""
+Conda environments and packages
+================================
+
+This module provides high-level tools for using conda environments.
+
+"""
+
+from fabtools.conda import (
+    is_conda_installed,
+    install_miniconda,
+    create_env,
+    env_exists,
+    env,
+    install,
+    is_installed
+)
+from fabtools.system import UnsupportedFamily, distrib_family
+
+
+def conda(prefix='~/miniconda', use_sudo=False):
+    """
+    Require conda to be installed.
+
+    If conda is not installed the latest version of miniconda will be installed.
+
+    :param prefix: prefix for the miniconda installation
+    :param use_sudo: use sudo for this operation
+    """
+    if not is_conda_installed():
+        install_miniconda(prefix=prefix, use_sudo=use_sudo)
+
+
+def env(name=None, pkg_list=None, **kwargs):
+    """
+    Require a conda environment.
+    If pkg_list is given, these are also required.
+
+    :param name: name of environment
+    :param pkg_list: list of required packages
+    :param **kwargs: arguments to fabtools.conda.create_env()
+    """
+
+    conda()
+
+    prefix = kwargs.get('prefix', None)
+    if not env_exists(name=name, prefix=prefix):
+        create_env(name=name, packages=pkg_list, **kwargs)
+    else:
+        packages(pkg_list, name=name, prefix=prefix, **kwargs)
+
+
+def package(pkg_name, name=None, prefix=None, **kwargs):
+    """
+    Require a conda package.
+
+    If the package is not installed, it will be installed using 'conda install'.
+    """
+
+    packages([pkg_name], name=name, prefix=prefix, **kwargs)
+
+
+def packages(pkg_list, name=None, prefix=None, **kwargs):
+    """
+    Require several conda packages.
+
+    """
+    install(pkg_list, name=name, prefix=prefix, **kwargs)

--- a/fabtools/tests/functional_tests/test_conda.py
+++ b/fabtools/tests/functional_tests/test_conda.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fabric.api import quiet, run, shell_env
+from fabric.api import quiet, run, shell_env, put
 
 from fabtools.files import is_link
 from fabtools.system import distrib_family, set_hostname
@@ -9,16 +9,29 @@ from fabtools import conda
 #pytestmark = pytest.mark.network
 
 
-def test_conda_install_and_check(setup_package):
+def test_conda_install_and_check():
     assert conda.is_conda_installed() == False
-    conda.install_miniconda()
+    conda.install_miniconda(keep_installer=True)
     assert conda.is_conda_installed()
+    run('rm -rf miniconda')
+    assert conda.is_conda_installed() == False
+    conda.install_miniconda(prefix='~/myminiconda', keep_installer=True)
+    assert conda.is_conda_installed()
+    run('rm -rf myminiconda')
+    assert conda.is_conda_installed() == False
+    conda.install_miniconda(keep_installer=True)
 
 
-def test_conda_create(setup_package):
+def test_conda_create():
     conda.create_env(name='test1', packages=['python=2.7'])
     conda.env_exists(name='test1')
     conda.create_env(prefix='testenvs/test1')
     conda.env_exists(prefix='testenvs/test1')
     conda.env_exists(prefix='testenvs/', name='test1')
     conda.env_exists(prefix='testenvs', name='test1')
+
+
+def test_conda_env_decorator():
+    conda.create_env(name='test2', packages=['python=2.7'])
+    with(conda.env('test2')):
+        assert run('python --version 2>&1 | grep -q -e "Python 2.7"').succeeded

--- a/fabtools/tests/functional_tests/test_conda.py
+++ b/fabtools/tests/functional_tests/test_conda.py
@@ -1,0 +1,24 @@
+import pytest
+
+from fabric.api import quiet, run, shell_env
+
+from fabtools.files import is_link
+from fabtools.system import distrib_family, set_hostname
+from fabtools import conda
+
+#pytestmark = pytest.mark.network
+
+
+def test_conda_install_and_check(setup_package):
+    assert conda.is_conda_installed() == False
+    conda.install_miniconda()
+    assert conda.is_conda_installed()
+
+
+def test_conda_create(setup_package):
+    conda.create_env(name='test1', packages=['python=2.7'])
+    conda.env_exists(name='test1')
+    conda.create_env(prefix='testenvs/test1')
+    conda.env_exists(prefix='testenvs/test1')
+    conda.env_exists(prefix='testenvs/', name='test1')
+    conda.env_exists(prefix='testenvs', name='test1')

--- a/fabtools/tests/functional_tests/test_conda.py
+++ b/fabtools/tests/functional_tests/test_conda.py
@@ -1,12 +1,9 @@
 import pytest
 
-from fabric.api import quiet, run, shell_env, put
+from fabric.api import run
 
-from fabtools.files import is_link
-from fabtools.system import distrib_family, set_hostname
-from fabtools import conda
-
-#pytestmark = pytest.mark.network
+from fabtools import conda, utils
+from fabtools import require
 
 
 def test_conda_install_and_check():
@@ -16,6 +13,7 @@ def test_conda_install_and_check():
     run('rm -rf miniconda')
     assert conda.is_conda_installed() == False
     conda.install_miniconda(prefix='~/myminiconda', keep_installer=True)
+    assert conda.get_sysprefix() == utils.abspath('myminiconda')
     assert conda.is_conda_installed()
     run('rm -rf myminiconda')
     assert conda.is_conda_installed() == False
@@ -35,3 +33,44 @@ def test_conda_env_decorator():
     conda.create_env(name='test2', packages=['python=2.7'])
     with(conda.env('test2')):
         assert run('python --version 2>&1 | grep -q -e "Python 2.7"').succeeded
+
+
+def test_package_installation():
+    conda.create_env('test3')
+    with conda.env('test3'):
+        assert conda.is_installed('six') == False
+        conda.install('six')
+        assert conda.is_installed('six')
+
+
+def test_require_conda():
+     if conda.is_conda_installed():
+         prefix = conda.get_sysprefix()
+         run('rm -rf ' + utils.abspath(prefix))
+         assert conda.is_conda_installed() == False
+     require.conda.conda()
+     assert conda.is_conda_installed()
+
+
+def test_require_env():
+    # Env creation without package list:
+    assert conda.env_exists('require-env') == False
+    require.conda.env('require-env')
+    assert conda.env_exists('require-env')
+    # Env creation with package list:
+    assert conda.env_exists('require-env2') == False
+    require.conda.env('require-env2', pkg_list=['python','six'])
+    assert conda.env_exists('require-env2')
+    with conda.env('require-env2'):
+        assert conda.is_installed('six')
+    # Requiring packages:
+    with conda.env('require-env2'):
+        assert conda.is_installed('redis') == False
+        assert conda.is_installed('yaml') == False
+        assert conda.is_installed('future') == False
+        require.conda.package('redis')
+        assert conda.is_installed('redis')
+        require.conda.packages(['yaml','future'])
+        assert conda.is_installed('yaml')
+        assert conda.is_installed('future')
+


### PR DESCRIPTION
The [conda](http://conda.pydata.org/docs/) package manager is gaining popularity, mostly in the scientific Python community. It allows installation of binary packages in separate environments, similar to Python virtualenvs, but not limited to Python packages.

The tools added in these commits (fabtools.conda, fabtools.require.conda) allow the installation of miniconda (a minimal conda environment) as well as setting up conda environments, package installation etc., much like the fabtools.python and fabtools.require.python packages