### PR TITLE
add-apt-repository moved to package software-properties-common in 14.04

### DIFF
--- a/fabtools/require/deb.py
+++ b/fabtools/require/deb.py
@@ -110,7 +110,11 @@ def ppa(name, auto_accept=True, keyserver=None):
     source = '/etc/apt/sources.list.d/%(user)s-%(repo)s-%(distrib)s.list' % locals()
 
     if not is_file(source):
-        package('python-software-properties')
+        if release >= 14.04:
+            # add-apt-repository moved to software-properties-common in 14.04
+            package('software-properties-common')
+        else:
+            package('python-software-properties')
         run_as_root('add-apt-repository %(auto_accept)s %(keyserver)s %(name)s' % locals(), pty=False)
         update_index()
 


### PR DESCRIPTION
add-apt-repository Ubuntu package:
- 'python-software-properties' in 12.04 (precise)
- 'software-properties-common' in 14.04 (trusty)

http://packages.ubuntu.com/precise/all/python-software-properties/filelist
http://packages.ubuntu.com/trusty/all/software-properties-common/filelist
