### PR TITLE
Change maxsplit argument value to 1.

### DIFF
--- a/fabtools/vagrant.py
+++ b/fabtools/vagrant.py
@@ -37,7 +37,7 @@ def ssh_config(name=''):
 
     config = {}
     for line in output.splitlines()[1:]:
-        key, value = line.strip().split(' ', 2)
+        key, value = line.strip().split(' ', 1)
         config[key] = value
     return config
 


### PR DESCRIPTION
Split needs to happen only once in order to get two values. Vagrantfile can output strings containing many space characters which results in exception "ValueError: too many values to unpack"