### PR TITLE
Escaped user name in create_user

### DIFF
--- a/fabtools/postgres.py
+++ b/fabtools/postgres.py
@@ -58,7 +58,7 @@ def create_user(name, password, superuser=False, createdb=False,
     password_type = 'ENCRYPTED' if encrypted_password else 'UNENCRYPTED'
     options.append("%s PASSWORD '%s'" % (password_type, password))
     options = ' '.join(options)
-    _run_as_pg('''psql -c "CREATE USER %(name)s %(options)s;"''' % locals())
+    _run_as_pg('''psql -c "CREATE USER \"%(name)s\" %(options)s;"''' % locals())
 
 
 def drop_user(name):

--- a/fabtools/postgres.py
+++ b/fabtools/postgres.py
@@ -58,7 +58,7 @@ def create_user(name, password, superuser=False, createdb=False,
     password_type = 'ENCRYPTED' if encrypted_password else 'UNENCRYPTED'
     options.append("%s PASSWORD '%s'" % (password_type, password))
     options = ' '.join(options)
-    _run_as_pg('''psql -c "CREATE USER \"%(name)s\" %(options)s;"''' % locals())
+    _run_as_pg('''psql -c "CREATE USER \\\\\"%(name)s\\\\\" %(options)s;"''' % locals())
 
 
 def drop_user(name):

--- a/fabtools/tests/test_postgres.py
+++ b/fabtools/tests/test_postgres.py
@@ -18,7 +18,7 @@ class TestRequirePostgresDatabase(unittest.TestCase):
         underlying create_database call
         """
         from fabtools import require
-        database_exists.return_value = Falsec
+        database_exists.return_value = False
         run.return_value = 'en-US.UTF-8\nde-DE.UTF-8'
         require.postgres.database('foo', 'bar', locale='some_locale',
                                   encoding='some_encoding',

--- a/fabtools/tests/test_postgres.py
+++ b/fabtools/tests/test_postgres.py
@@ -58,7 +58,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar')
         expected = (
-            'psql -c "CREATE USER "foo" NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER \\"foo\\" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -67,7 +67,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar', connection_limit=-1)
         expected = (
-            'psql -c "CREATE USER "foo" NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER \\"foo\\" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN CONNECTION LIMIT -1 UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -78,7 +78,7 @@ class TestPostgresCreateUser(unittest.TestCase):
                              createrole=True, inherit=False, login=False,
                              connection_limit=20, encrypted_password=True)
         expected = (
-            'psql -c "CREATE USER "foo" SUPERUSER CREATEDB CREATEROLE '
+            'psql -c "CREATE USER \\"foo\\" SUPERUSER CREATEDB CREATEROLE '
             'NOINHERIT NOLOGIN CONNECTION LIMIT 20 '
             'ENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])

--- a/fabtools/tests/test_postgres.py
+++ b/fabtools/tests/test_postgres.py
@@ -58,7 +58,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar')
         expected = (
-            'psql -c "CREATE USER \\"foo\\" NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER \\\\"foo\\\\" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -67,7 +67,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar', connection_limit=-1)
         expected = (
-            'psql -c "CREATE USER \\"foo\\" NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER \\\\"foo\\\\" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN CONNECTION LIMIT -1 UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -78,7 +78,7 @@ class TestPostgresCreateUser(unittest.TestCase):
                              createrole=True, inherit=False, login=False,
                              connection_limit=20, encrypted_password=True)
         expected = (
-            'psql -c "CREATE USER \\"foo\\" SUPERUSER CREATEDB CREATEROLE '
+            'psql -c "CREATE USER \\\\"foo\\\\" SUPERUSER CREATEDB CREATEROLE '
             'NOINHERIT NOLOGIN CONNECTION LIMIT 20 '
             'ENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])

--- a/fabtools/tests/test_postgres.py
+++ b/fabtools/tests/test_postgres.py
@@ -18,7 +18,7 @@ class TestRequirePostgresDatabase(unittest.TestCase):
         underlying create_database call
         """
         from fabtools import require
-        database_exists.return_value = False
+        database_exists.return_value = Falsec
         run.return_value = 'en-US.UTF-8\nde-DE.UTF-8'
         require.postgres.database('foo', 'bar', locale='some_locale',
                                   encoding='some_encoding',
@@ -58,7 +58,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar')
         expected = (
-            'psql -c "CREATE USER foo NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER "foo" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -67,7 +67,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar', connection_limit=-1)
         expected = (
-            'psql -c "CREATE USER foo NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER "foo" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN CONNECTION LIMIT -1 UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -78,7 +78,7 @@ class TestPostgresCreateUser(unittest.TestCase):
                              createrole=True, inherit=False, login=False,
                              connection_limit=20, encrypted_password=True)
         expected = (
-            'psql -c "CREATE USER foo SUPERUSER CREATEDB CREATEROLE '
+            'psql -c "CREATE USER "foo" SUPERUSER CREATEDB CREATEROLE '
             'NOINHERIT NOLOGIN CONNECTION LIMIT 20 '
             'ENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])


### PR DESCRIPTION
For example I have a linux user named as "www.test.com" and I want to create a postgresql user for it. Luckily Postgresql supports dot in names, unfortunately you need to escape when creating a user.
