### PR TITLE
Add param "options" to require.deb.package

### DIFF
--- a/fabtools/require/deb.py
+++ b/fabtools/require/deb.py
@@ -134,7 +134,7 @@ def package(pkg_name, update=False, options=None, version=None):
         install(pkg_name, update=update, options=options, version=version)
 
 
-def packages(pkg_list, update=False):
+def packages(pkg_list, update=False, options=None):
     """
     Require several deb packages to be installed.
 
@@ -150,7 +150,7 @@ def packages(pkg_list, update=False):
     """
     pkg_list = [pkg for pkg in pkg_list if not is_installed(pkg)]
     if pkg_list:
-        install(pkg_list, update)
+        install(pkg_list, update=update, options=options)
 
 
 def nopackage(pkg_name):

--- a/fabtools/require/deb.py
+++ b/fabtools/require/deb.py
@@ -115,7 +115,7 @@ def ppa(name, auto_accept=True, keyserver=None):
         update_index()
 
 
-def package(pkg_name, update=False, version=None):
+def package(pkg_name, update=False, options=None, version=None):
     """
     Require a deb package to be installed.
 
@@ -131,7 +131,7 @@ def package(pkg_name, update=False, version=None):
 
     """
     if not is_installed(pkg_name):
-        install(pkg_name, update=update, version=version)
+        install(pkg_name, update=update, options=options, version=version)
 
 
 def packages(pkg_list, update=False):


### PR DESCRIPTION
I would like the function `fabtools.require.deb.package` [(doc)](https://fabtools.readthedocs.org/en/0.19.0/api/require/deb.html#fabtools.require.deb.package) have the parameter `option` which is available in function `fabtools.deb.install` [(doc)](https://fabtools.readthedocs.org/en/0.19.0/api/deb.html#fabtools.deb.install).

That parameter could be useful for passing the parameter `--no-install-recommends` for example.

Related issue: #287 
