### PR TITLE
Fix requires.files.file(url) when url contains '&'

### DIFF
--- a/fabtools/require/files.py
+++ b/fabtools/require/files.py
@@ -145,7 +145,7 @@ def file(path=None, contents=None, source=None, url=None, md5=None,
             path = os.path.basename(urlparse(url).path)
 
         if not is_file(path) or md5 and md5sum(path) != md5:
-            func('wget --progress=dot:mega %(url)s -O %(path)s' % locals())
+            func('wget --progress=dot:mega "%(url)s" -O "%(path)s"' % locals())
 
     # 3) A local filename, or a content string, is specified
     else:


### PR DESCRIPTION
Hi!

Function `requires.files.file(url)` fails when the url contains the character `&`, as found e.g. in Amazon S3 download links, and many more places.

Taking a look to the source code, wget is invoked the following way:

```
func('wget --progress=dot:mega %(url)s -O %(path)s' % locals())
```

The problem could be easily solved using double quotes around `%(url)s` and `%(path)s` in the following way:

```
func('wget --progress=dot:mega "%(url)s" -O "%(path)s"' % locals())
```

Thanks!

Related issue: https://github.com/ronnix/fabtools/issues/261
