### PR TITLE
Fix different sfdisk version

### DIFF
--- a/fabtools/disk.py
+++ b/fabtools/disk.py
@@ -30,9 +30,19 @@ def partitions(device=""):
     with settings(hide('running', 'stdout')):
         res = run_as_root('sfdisk -d %(device)s' % locals())
 
-        spart = re.compile(r'(?P<pname>^/.*) : .* Id=(?P<ptypeid>[0-9a-z]+)')
+        # Old SFIDSK
+        spartid = re.compile(r'(?P<pname>^/.*) : .* Id=(?P<ptypeid>[0-9a-z]+)')
+        # NEW SFDISK
+        spartid = re.compile(r'(?P<pname>^/.*) : .* type=(?P<ptypeid>[0-9a-z]+)')
         for line in res.splitlines():
-            m = spart.search(line)
+
+            # Old SFIDSK
+            m = spartid.search(line)
+            if m:
+                partitions_list[m.group('pname')] = int(m.group('ptypeid'), 16)
+
+            # NEW SFDISK
+            m = spartid.search(line)
             if m:
                 partitions_list[m.group('pname')] = int(m.group('ptypeid'), 16)
 

--- a/fabtools/disk.py
+++ b/fabtools/disk.py
@@ -32,19 +32,19 @@ def partitions(device=""):
 
         # Old SFIDSK
         spartid = re.compile(r'(?P<pname>^/.*) : .* Id=(?P<ptypeid>[0-9a-z]+)')
-        # NEW SFDISK
-        spartid = re.compile(r'(?P<pname>^/.*) : .* type=(?P<ptypeid>[0-9a-z]+)')
+        # New SFDISK
+        sparttype = re.compile(r'(?P<pname>^/.*) : .* type=(?P<ptypeid>[0-9a-z]+)')
         for line in res.splitlines():
 
             # Old SFIDSK
             m = spartid.search(line)
             if m:
                 partitions_list[m.group('pname')] = int(m.group('ptypeid'), 16)
-
-            # NEW SFDISK
-            m = spartid.search(line)
-            if m:
-                partitions_list[m.group('pname')] = int(m.group('ptypeid'), 16)
+            else:
+                # New SFDISK
+                m = sparttype.search(line)
+                if m:
+                    partitions_list[m.group('pname')] = int(m.group('ptypeid'), 16)
 
     return partitions_list
 


### PR DESCRIPTION
It seems, that the sfdisk have changed the output result with the newer version. In the older version, the partition type = "Id=xx" and in the newer version, the partion type = "type=xx". This fix work for older and newer version