### PR TITLE
In fabtools.postgres.create_user, put username in double quotes.

### DIFF
--- a/fabtools/postgres.py
+++ b/fabtools/postgres.py
@@ -58,7 +58,7 @@ def create_user(name, password, superuser=False, createdb=False,
     password_type = 'ENCRYPTED' if encrypted_password else 'UNENCRYPTED'
     options.append("%s PASSWORD '%s'" % (password_type, password))
     options = ' '.join(options)
-    _run_as_pg('''psql -c "CREATE USER %(name)s %(options)s;"''' % locals())
+    _run_as_pg('''psql -c "CREATE USER "'"%(name)s"'" %(options)s;"''' % locals())
 
 
 def drop_user(name):

--- a/fabtools/tests/test_postgres.py
+++ b/fabtools/tests/test_postgres.py
@@ -58,7 +58,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar')
         expected = (
-            'psql -c "CREATE USER foo NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER "\'"foo"\'" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -67,7 +67,7 @@ class TestPostgresCreateUser(unittest.TestCase):
         from fabtools import postgres
         postgres.create_user('foo', 'bar', connection_limit=-1)
         expected = (
-            'psql -c "CREATE USER foo NOSUPERUSER NOCREATEDB NOCREATEROLE '
+            'psql -c "CREATE USER "\'"foo"\'" NOSUPERUSER NOCREATEDB NOCREATEROLE '
             'INHERIT LOGIN CONNECTION LIMIT -1 UNENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])
 
@@ -78,7 +78,7 @@ class TestPostgresCreateUser(unittest.TestCase):
                              createrole=True, inherit=False, login=False,
                              connection_limit=20, encrypted_password=True)
         expected = (
-            'psql -c "CREATE USER foo SUPERUSER CREATEDB CREATEROLE '
+            'psql -c "CREATE USER "\'"foo"\'" SUPERUSER CREATEDB CREATEROLE '
             'NOINHERIT NOLOGIN CONNECTION LIMIT 20 '
             'ENCRYPTED PASSWORD \'bar\';"')
         self.assertEqual(expected, _run_as_pg.call_args[0][0])


### PR DESCRIPTION
Creating postgres users with dashes in username was not working for me. e.g.

    require.postgres.user("foo-user", password=None)

If, in the generated SQL, username is in double quotes, it works.