### PR TITLE
py3k compatible setuptools check

### DIFF
--- a/fabtools/python_setuptools.py
+++ b/fabtools/python_setuptools.py
@@ -26,7 +26,7 @@ def package_version(name, python_cmd='python'):
     cmd = '''%(python_cmd)s -c \
         "import pkg_resources;\
         dist = pkg_resources.get_distribution('%(name)s');\
-        print dist.version"
+        print(dist.version)"
         ''' % locals()
     res = run(cmd, quiet=True)
     if res.succeeded:


### PR DESCRIPTION
Use Python 3 compatible print statement when checking setuptools. Otherwise the function always returns False.