### PR TITLE
Fix a typo in a docstring

### DIFF
--- a/fabtools/files.py
+++ b/fabtools/files.py
@@ -213,7 +213,7 @@ class watch(object):
         from fabric.contrib.files import comment, uncomment
 
         from fabtools.files import watch
-        from fabtools.services import restart
+        from fabtools.service import restart
 
         # Edit configuration file
         with watch('/etc/daemon.conf') as config:
@@ -231,7 +231,7 @@ class watch(object):
         from fabric.contrib.files import comment, uncomment
 
         from fabtools.files import watch
-        from fabtools.services import restart
+        from fabtools.service import restart
 
         with watch('/etc/daemon.conf', callback=partial(restart, 'daemon')):
             uncomment('/etc/daemon.conf', 'someoption')

--- a/fabtools/require/nginx.py
+++ b/fabtools/require/nginx.py
@@ -83,7 +83,7 @@ def disabled(config):
 
         from fabtools import require
 
-        require.nginx.site_disabled('default')
+        require.nginx.disabled('default')
 
     """
     disable(config)


### PR DESCRIPTION
`fabtools.services` -> `fabtools.service`, see http://fabtools.readthedocs.org/en/latest/api/service.html.