### PR TITLE
Add username whitespace removal to require.users.sudoer

### DIFF
--- a/fabtools/require/users.py
+++ b/fabtools/require/users.py
@@ -67,7 +67,7 @@ def sudoer(username, hosts="ALL", operators="ALL", passwd=False,
     tags = "PASSWD:" if passwd else "NOPASSWD:"
     spec = "%(username)s %(hosts)s=(%(operators)s) %(tags)s %(commands)s" %\
            locals()
-    filename = '/etc/sudoers.d/fabtools-%s' % username
+    filename = '/etc/sudoers.d/fabtools-%s' % username.strip()
     if is_file(filename):
         run_as_root('chmod 0640 %(filename)s && rm -f %(filename)s' % locals())
     run_as_root('echo "%(spec)s" >%(filename)s && chmod 0440 %(filename)s' %


### PR DESCRIPTION
Currently, if the user provides a username with leading whitespace, it totally borks the following commands.

If you prefer I raise an exception instead of stripping the string, I could do that.