### PR TITLE
Fix nodejs.package_version fails to read json

### DIFF
--- a/fabtools/nodejs.py
+++ b/fabtools/nodejs.py
@@ -165,7 +165,7 @@ def package_version(package, local=False, npm='npm'):
     options = ' '.join(options)
 
     with hide('running', 'stdout'):
-        res = run('%(npm)s list %(options)s' % locals())
+        res = run('%(npm)s list %(options)s' % locals(), pty=False)
 
     dependencies = json.loads(res).get('dependencies', {})
     pkg_data = dependencies.get(package)


### PR DESCRIPTION
Without `pty=False` the `run()` command returns back a json with a garbage like '\x1b[?25h\x1b[0G\x1b[K\x1b[?25h\x1b[0G\x1b[K' at the end, which causes `json.loads(res)` to fail.