### PR TITLE
python, require.python: Allow pty=False option to be overriden by user

### DIFF
--- a/fabtools/python.py
+++ b/fabtools/python.py
@@ -53,7 +53,7 @@ def is_pip_installed(version=None, pip_cmd='pip'):
                 return True
 
 
-def install_pip(python_cmd='python', use_sudo=True):
+def install_pip(python_cmd='python', use_sudo=True, pty=False):
     """
     Install the latest version of `pip`_, using the given Python
     interpreter.
@@ -70,6 +70,13 @@ def install_pip(python_cmd='python', use_sudo=True):
         is no need to install it yourself in this case.
 
     .. _pip: http://www.pip-installer.org/
+
+    .. note::
+        On some distros when installing pip system-wide with help of sudo
+        you might encounter rare error message:
+        ``sudo: sorry, you must have a tty to run sudo``.
+        In such circumstances you should run ``install_pip``
+        with argument ``pty=True``.
     """
 
     with cd('/tmp'):
@@ -78,9 +85,9 @@ def install_pip(python_cmd='python', use_sudo=True):
 
         command = '%(python_cmd)s get-pip.py' % locals()
         if use_sudo:
-            run_as_root(command, pty=False)
+            run_as_root(command, pty=pty)
         else:
-            run(command, pty=False)
+            run(command, pty=pty)
 
         run('rm -f get-pip.py')
 
@@ -111,7 +118,7 @@ def is_installed(package, pip_cmd='pip'):
 
 def install(packages, upgrade=False, download_cache=None, allow_external=None,
             allow_unverified=None, quiet=False, pip_cmd='pip', use_sudo=False,
-            user=None, exists_action=None):
+            user=None, exists_action=None, pty=False):
     """
     Install Python package(s) using `pip`_.
 
@@ -134,6 +141,13 @@ def install(packages, upgrade=False, download_cache=None, allow_external=None,
         fabtools.python.install(['pkg1', 'pkg2'], use_sudo=True)
 
     .. _pip: http://www.pip-installer.org/
+
+    .. note::
+        On some distros when installing packages system-wide with help of sudo
+        you might encounter rare error message:
+        ``sudo: sorry, you must have a tty to run sudo``.
+        In such circumstances you should run ``install`` with argument 
+        ``pty=True``.
     """
     if isinstance(packages, basestring):
         packages = [packages]
@@ -168,15 +182,15 @@ def install(packages, upgrade=False, download_cache=None, allow_external=None,
     command = '%(pip_cmd)s install %(options)s %(packages)s' % locals()
 
     if use_sudo:
-        sudo(command, user=user, pty=False)
+        sudo(command, user=user, pty=pty)
     else:
-        run(command, pty=False)
+        run(command, pty=pty)
 
 
 def install_requirements(filename, upgrade=False, download_cache=None,
                          allow_external=None, allow_unverified=None,
                          quiet=False, pip_cmd='pip', use_sudo=False,
-                         user=None, exists_action=None):
+                         user=None, exists_action=None, pty=False):
     """
     Install Python packages from a pip `requirements file`_.
 
@@ -212,9 +226,9 @@ def install_requirements(filename, upgrade=False, download_cache=None,
     command = '%(pip_cmd)s install %(options)s -r %(filename)s' % locals()
 
     if use_sudo:
-        sudo(command, user=user, pty=False)
+        sudo(command, user=user, pty=pty)
     else:
-        run(command, pty=False)
+        run(command, pty=pty)
 
 
 def create_virtualenv(directory, system_site_packages=False, venv_python=None,

--- a/fabtools/require/python.py
+++ b/fabtools/require/python.py
@@ -58,7 +58,7 @@ def setuptools(version=MIN_SETUPTOOLS_VERSION, python_cmd='python'):
         install_setuptools(python_cmd=python_cmd)
 
 
-def pip(version=MIN_PIP_VERSION, pip_cmd='pip', python_cmd='python'):
+def pip(version=MIN_PIP_VERSION, pip_cmd='pip', python_cmd='python', pty=False):
     """
     Require `pip`_ to be installed.
 
@@ -69,11 +69,11 @@ def pip(version=MIN_PIP_VERSION, pip_cmd='pip', python_cmd='python'):
     """
     setuptools(python_cmd=python_cmd)
     if not is_pip_installed(version, pip_cmd=pip_cmd):
-        install_pip(python_cmd=python_cmd)
+        install_pip(python_cmd=python_cmd, pty=pty)
 
 
 def package(pkg_name, url=None, pip_cmd='pip', python_cmd='python',
-            allow_external=False, allow_unverified=False, **kwargs):
+            allow_external=False, allow_unverified=False, pty=False, **kwargs):
     """
     Require a Python package.
 
@@ -101,17 +101,17 @@ def package(pkg_name, url=None, pip_cmd='pip', python_cmd='python',
 
     .. _pip installer: http://www.pip-installer.org/
     """
-    pip(MIN_PIP_VERSION, python_cmd=python_cmd)
+    pip(MIN_PIP_VERSION, python_cmd=python_cmd, pty=pty)
     if not is_installed(pkg_name, pip_cmd=pip_cmd):
         install(url or pkg_name,
                 pip_cmd=pip_cmd,
                 allow_external=[url or pkg_name] if allow_external else [],
                 allow_unverified=[url or pkg_name] if allow_unverified else [],
-                **kwargs)
+                pty=pty, **kwargs)
 
 
 def packages(pkg_list, pip_cmd='pip', python_cmd='python',
-             allow_external=None, allow_unverified=None, **kwargs):
+             allow_external=None, allow_unverified=None, pty=False, **kwargs):
     """
     Require several Python packages.
 
@@ -138,11 +138,12 @@ def packages(pkg_list, pip_cmd='pip', python_cmd='python',
                 pip_cmd=pip_cmd,
                 allow_external=allow_external,
                 allow_unverified=allow_unverified,
-                **kwargs)
+                pty=pty, **kwargs)
 
 
 def requirements(filename, pip_cmd='pip', python_cmd='python',
-                 allow_external=None, allow_unverified=None, **kwargs):
+                 allow_external=None, allow_unverified=None,
+                 pty=False, **kwargs):
     """
     Require Python packages from a pip `requirements file`_.
 
@@ -166,13 +167,13 @@ def requirements(filename, pip_cmd='pip', python_cmd='python',
     pip(MIN_PIP_VERSION, python_cmd=python_cmd)
     install_requirements(filename, pip_cmd=pip_cmd,
                          allow_external=allow_external,
-                         allow_unverified=allow_unverified, **kwargs)
+                         allow_unverified=allow_unverified, pty=pty, **kwargs)
 
 
 def virtualenv(directory, system_site_packages=False, venv_python=None,
                use_sudo=False, user=None, clear=False, prompt=None,
                virtualenv_cmd='virtualenv', pip_cmd='pip',
-               python_cmd='python'):
+               python_cmd='python', pty=False):
     """
     Require a Python `virtual environment`_.
 
@@ -186,7 +187,7 @@ def virtualenv(directory, system_site_packages=False, venv_python=None,
     """
 
     package('virtualenv', use_sudo=True, pip_cmd=pip_cmd,
-            python_cmd=python_cmd)
+            python_cmd=python_cmd, pty=pty)
 
     if not virtualenv_exists(directory):
         create_virtualenv(


### PR DESCRIPTION
Better support of CentOS 7.2 (or perhaps entire RHEL family) when sudo policy has "Defaults requiretty" option set.

Allow user of fabtools to override hardcoded pty=False when fabtools about to launch fabric.sudo().
This helps to avoid error message  "sudo: sorry, you must have a tty to run sudo".

Issue https://github.com/fabtools/fabtools/issues/332