### PR TITLE
Use systemd is-active instead of status

### DIFF
--- a/fabtools/systemd.py
+++ b/fabtools/systemd.py
@@ -56,7 +56,7 @@ def is_running(service):
     """
     with settings(
             hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
-        return action('status', service).succeeded
+        return action('is-active', service).succeeded
 
 
 def start(service):


### PR DESCRIPTION
Because status won't exit when there is more than a screen full of output to show and this causes fabtools to hang.