### PR TITLE
A couple tools for Centos 7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 Sphinx
 sphinx_rtd_theme
 tox>=2.0.0
+mock

--- a/fabtools/editor.py
+++ b/fabtools/editor.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+from fabric.contrib.files import sed
+from functools import partial
+
+
+Line = namedtuple("Line", "regex before after")
+
+
+def update_line(path, regex, before, after, use_sudo=False):
+    _sed = partial(sed, path, use_sudo=use_sudo)
+    _sed(before=before, after=after, limit=regex)
+
+
+def update_file(path, lines, use_sudo=False):
+    """
+    Example:
+
+        path = '/etc/php.ini'
+        lines = [
+            Line('memory_limit', '= .*', '= 256M'),
+            Line('session.gc_maxlifetime', '= .*', '= 7200'),
+        ]
+        update_file(path, lines, use_sudo=True)
+
+    """
+    for line in lines:
+        update_line(path, line.regex, line.before, line.after, use_sudo)

--- a/fabtools/files.py
+++ b/fabtools/files.py
@@ -315,10 +315,11 @@ def symlink(source, destination, use_sudo=False):
     func('/bin/ln -s {0} {1}'.format(quote(source), quote(destination)))
 
 
-def remove(path, recursive=False, use_sudo=False):
+def remove(path, recursive=False, force=False, use_sudo=False):
     """
     Remove a file or directory
     """
     func = use_sudo and run_as_root or run
     options = '-r ' if recursive else ''
+    options += '-f ' if force else ''
     func('/bin/rm {0}{1}'.format(options, quote(path)))

--- a/fabtools/files.py
+++ b/fabtools/files.py
@@ -289,37 +289,42 @@ def getmtime(path, use_sudo=False):
         return int(func('stat -c %%Y "%(path)s" ' % locals()).strip())
 
 
-def copy(source, destination, recursive=False, use_sudo=False):
+def copy(source, destination, recursive=False, use_sudo=False, do_quote=True):
     """
     Copy a file or directory
     """
     func = use_sudo and run_as_root or run
+    quote_func = quote if do_quote else lambda x: x
     options = '-r ' if recursive else ''
     func('/bin/cp {0}{1} {2}'.format(
-        options, quote(source), quote(destination)))
+        options, quote_func(source), quote_func(destination)))
 
 
-def move(source, destination, use_sudo=False):
+def move(source, destination, use_sudo=False, do_quote=True):
     """
     Move a file or directory
     """
     func = use_sudo and run_as_root or run
-    func('/bin/mv {0} {1}'.format(quote(source), quote(destination)))
+    quote_func = quote if do_quote else lambda x: x
+    func('/bin/mv {0} {1}'.format(quote_func(source), quote_func(destination)))
 
 
-def symlink(source, destination, use_sudo=False):
+def symlink(source, destination, use_sudo=False, do_quote=True):
     """
     Create a symbolic link to a file or directory
     """
     func = use_sudo and run_as_root or run
-    func('/bin/ln -s {0} {1}'.format(quote(source), quote(destination)))
+    quote_func = quote if do_quote else lambda x: x
+    func('/bin/ln -s {0} {1}'.format(
+          quote_func(source), quote_func(destination)))
 
 
-def remove(path, recursive=False, force=False, use_sudo=False):
+def remove(path, recursive=False, force=False, use_sudo=False, do_quote=True):
     """
     Remove a file or directory
     """
     func = use_sudo and run_as_root or run
+    quote_func = quote if do_quote else lambda x: x
     options = '-r ' if recursive else ''
     options += '-f ' if force else ''
-    func('/bin/rm {0}{1}'.format(options, quote(path)))
+    func('/bin/rm {0}{1}'.format(options, quote_func(path)))

--- a/fabtools/firewalld.py
+++ b/fabtools/firewalld.py
@@ -18,16 +18,16 @@ def open_port(port, proto, zone='public', permanent=True, reload_fw=True):
 
 
 def start():
-    systemd.start(name='firewalld')
+    systemd.start('firewalld')
 
 
 def stop():
-    systemd.stop(name='firewalld')
+    systemd.stop('firewalld')
 
 
 def enable():
-    systemd.enable(name='firewalld')
+    systemd.enable('firewalld')
 
 
 def disable():
-    systemd.disable(name='firewalld')
+    systemd.disable('firewalld')

--- a/fabtools/firewalld.py
+++ b/fabtools/firewalld.py
@@ -1,0 +1,33 @@
+from fabric.api import sudo
+from fabtools import systemd
+
+
+def reload():
+    cmd = 'firewall-cmd --reload'
+    sudo(cmd)
+
+
+def open_port(port, proto, zone='public', permanent=True, reload=True):
+    cmd = ('firewall-cmd --zone={zone} --add-port={port}/{proto}'.format(
+           zone=zone, port=port, proto=proto))
+    if permanent:
+        cmd += ' --permanent'
+    sudo(cmd)
+    if reload:
+        reload()
+
+
+def start():
+    systemd.start(name='firewalld')
+
+
+def stop():
+    systemd.stop(name='firewalld')
+
+
+def enable():
+    systemd.enable(name='firewalld')
+
+
+def disable():
+    systemd.disable(name='firewalld')

--- a/fabtools/firewalld.py
+++ b/fabtools/firewalld.py
@@ -7,13 +7,13 @@ def reload():
     sudo(cmd)
 
 
-def open_port(port, proto, zone='public', permanent=True, reload=True):
+def open_port(port, proto, zone='public', permanent=True, reload_fw=True):
     cmd = ('firewall-cmd --zone={zone} --add-port={port}/{proto}'.format(
            zone=zone, port=port, proto=proto))
     if permanent:
         cmd += ' --permanent'
     sudo(cmd)
-    if reload:
+    if reload_fw:
         reload()
 
 

--- a/fabtools/mysql.py
+++ b/fabtools/mysql.py
@@ -138,3 +138,35 @@ def create_database(name, owner=None, owner_host='localhost', charset='utf8',
             }, **kwargs)
 
     puts("Created MySQL database '%s'." % name)
+
+
+def table_empty(name, database, **kwargs):
+    """
+    Check if a MySQL table is empty
+    """
+    with settings(
+            hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
+        res = query("""
+            use %(database)s;
+            SELECT * FROM %(name)s;""" % {
+                'name': name,
+                'database': database
+            }, **kwargs)
+
+    return res.succeeded and (res == '')
+
+
+def table_exists(name, database, **kwargs):
+    """
+    Check if a MySQL table exists.
+    """
+    with settings(
+            hide('running', 'stdout', 'stderr', 'warnings'), warn_only=True):
+        res = query("""
+            use %(database)s;
+            SHOW TABLES LIKE '%(name)s';""" % {
+                'name': name,
+                'database': database
+            }, **kwargs)
+
+    return res.succeeded and (res == name)

--- a/fabtools/selinux.py
+++ b/fabtools/selinux.py
@@ -1,0 +1,50 @@
+from fabric.api import sudo, abort
+from fabtools.utils import grep
+from fabtools.editor import (Line, update_file)
+
+
+def add_port(port_type, port):
+    if not grep('semanage port -l',
+                'http_port_t.*\s+{port}[\s+,\\n]'.format(port=port)):
+        sudo("semanage port -a -t %(port_type)s -p tcp %(port)" % locals())
+
+
+def add_ports(type, ports):
+    for port in ports:
+        add_port(port_type='http_port_t', port=port)
+
+
+def setsebool(selinux_boolean, value):
+    result = sudo("getsebool {0}".format(selinux_boolean))
+    if '--> on' in result and value == 0:
+        sudo("setsebool -P {0} 0".format(selinux_boolean))
+    elif '--> off' in result and value == 1:
+        sudo("setsebool -P {0} 1".format(selinux_boolean))
+
+
+def set_policy(policy='unset', permanent=True):
+    allowed_policies = ['permissive', 'enforcing', 'disabled']
+    if policy not in allowed_policies:
+        msg = 'SELinux policy unspecified. Specify one of: {0}'.format(
+                ', '.join(allowed_policies))
+        abort(msg)
+    if policy == 'permissive':
+        sudo('setenforce 0')
+    elif policy == 'enforcing':
+        sudo('setenforce 1')
+
+    if permanent:
+        lines = [Line('^SELINUX[ \t]*=.*$', '=.*', '={0}'.format(policy))]
+        update_file('/etc/sysconfig/selinux', lines)
+
+
+def set_permissive(permanent=True):
+    set_policy('permissive', permanent)
+
+
+def set_enforcing(permanent=True):
+    set_policy('enforcing', permanent)
+
+
+def set_disabled(permanent=True):
+    set_policy('disabled', permanent)

--- a/fabtools/selinux.py
+++ b/fabtools/selinux.py
@@ -6,7 +6,7 @@ from fabtools.editor import (Line, update_file)
 def add_port(port_type, port):
     if not grep('semanage port -l',
                 'http_port_t.*\s+{port}[\s+,\\n]'.format(port=port)):
-        sudo("semanage port -a -t %(port_type)s -p tcp %(port)" % locals())
+        sudo("semanage port -a -t %(port_type)s -p tcp %(port)s" % locals())
 
 
 def add_ports(type, ports):

--- a/fabtools/selinux.py
+++ b/fabtools/selinux.py
@@ -5,7 +5,8 @@ from fabtools.editor import (Line, update_file)
 
 def add_port(port_type, port):
     if not grep('semanage port -l',
-                'http_port_t.*\s+{port}[\s+,\\n]'.format(port=port)):
+                'http_port_t.*\s+{port}[\s+,\\n]'.format(port=port),
+                use_sudo=True):
         sudo("semanage port -a -t %(port_type)s -p tcp %(port)s" % locals())
 
 

--- a/fabtools/selinux.py
+++ b/fabtools/selinux.py
@@ -35,7 +35,7 @@ def set_policy(policy='unset', permanent=True):
 
     if permanent:
         lines = [Line('^SELINUX[ \t]*=.*$', '=.*', '={0}'.format(policy))]
-        update_file('/etc/sysconfig/selinux', lines)
+        update_file('/etc/sysconfig/selinux', lines, use_sudo=True)
 
 
 def set_permissive(permanent=True):

--- a/fabtools/system.py
+++ b/fabtools/system.py
@@ -3,7 +3,7 @@ System settings
 ===============
 """
 
-from fabric.api import hide, run, settings
+from fabric.api import hide, run, settings, abort
 
 from fabtools.files import is_file
 from fabtools.utils import read_lines, run_as_root
@@ -308,3 +308,16 @@ def time():
 
     with settings(hide('running', 'stdout')):
         return int(run('date +%s'))
+
+
+def get_timezone():
+    if using_systemd():
+        cmd = 'timedatectl | sed -n \'/Time zone/ s/.*Time zone: \([^ ]*\).*/\\1/p\''
+        res = run(cmd)
+    else:
+        path = '/etc/sysconfig/clock'
+        cmd = 'sed -n \'/ZONE/ s/.*"\(.*\)".*/\\1/p\' {0}'.format(path)
+        res = run(cmd)
+    if not res.succeeded:
+        abort("Unable to get time zone")
+    return res.strip()

--- a/fabtools/system.py
+++ b/fabtools/system.py
@@ -315,9 +315,18 @@ def get_timezone():
         cmd = 'timedatectl | sed -n \'/Time zone/ s/.*Time zone: \([^ ]*\).*/\\1/p\''
         res = run(cmd)
     else:
-        path = '/etc/sysconfig/clock'
-        cmd = 'sed -n \'/ZONE/ s/.*"\(.*\)".*/\\1/p\' {0}'.format(path)
-        res = run(cmd)
+        family = distrib_family()
+        if family == 'debian':
+            path = '/etc/timezone'
+            cmd = 'cat {0}'.format(path)
+            res = run(cmd)
+        elif family == 'redhat':
+            path = '/etc/sysconfig/clock'
+            cmd = 'sed -n \'/ZONE/ s/.*"\(.*\)".*/\\1/p\' {0}'.format(path)
+            res = run(cmd)
+        else:
+            raise UnsupportedFamily(supported=['debian', 'redhat'])
+
     if not res.succeeded:
         abort("Unable to get time zone")
     return res.strip()

--- a/fabtools/systemd.py
+++ b/fabtools/systemd.py
@@ -134,3 +134,16 @@ def stop_and_disable(service):
     """
     stop(service)
     disable(service)
+
+
+def status(service):
+    """
+    Run systemctl status ``service``
+
+    ::
+
+        fabtools.systemd.status('httpd')
+
+    .. note:: This function is idempotent.
+    """
+    action('status', service)

--- a/fabtools/utils.py
+++ b/fabtools/utils.py
@@ -69,7 +69,7 @@ def grep(command, grep_for, use_sudo=False):
     ``False`` otherwise.
     """
     func = use_sudo and run_as_root or run
-    command = "{command} | egrep '{grep_for}'" % locals()
+    command = "%(command)s | egrep '%(grep_for)s'" % locals()
     if func(command, warn_only=True, quiet=True).succeeded:
         return True
     return False

--- a/fabtools/utils.py
+++ b/fabtools/utils.py
@@ -59,3 +59,17 @@ def read_file(path):
 
 def read_lines(path):
     return read_file(path).splitlines()
+
+
+def grep(command, grep_for, use_sudo=False):
+    """
+    Run a command and grep its output for a string.
+
+    Returns ``True`` if ``grep_for`` is found in the ``command``'s output,
+    ``False`` otherwise.
+    """
+    func = use_sudo and run_as_root or run
+    command = "{command} | egrep '{grep_for}'" % locals()
+    if func(command, warn_only=True, quiet=True).succeeded:
+        return True
+    return False

--- a/fabtools/yum.py
+++ b/fabtools/yum.py
@@ -1,0 +1,17 @@
+from fabtools import require
+from fabtools.utils import run_as_root
+
+
+def add_repo(repo_file_url):
+    require.rpm.package('yum-utils')
+    run_as_root('yum-config-manager --add-repo %(repo_file_url)s' % locals())
+
+
+def enable_repo(repo_id):
+    require.rpm.package('yum-utils')
+    run_as_root('yum-config-manager --enable %(repo_id)s' % locals())
+
+
+def disable_repo(repo_id):
+    require.rpm.package('yum-utils')
+    run_as_root('yum-config-manager --disable %(repo_id)s' % locals())


### PR DESCRIPTION
Added a few functionalities I needed:
- editor - syntax sugar for fabric's sed:
  - Makes updating a file more readable
- copy/move/remove/symlink - quoting is optional:
  - it's on by default, so backward compatibility isn't broken
  - needed if one needs to use patterns while copying, say cp -r /some/path/*.conf /etc/httpd/confi.d/
- Basic functionality for firewalld added
- mysql updated:
  - check for an empty table and check if a table exists
- basic selinux functionality added
- get_timezone added to system
- systemd - status added
- added grep to utils to check whether a string is found in a command's output
- yum added - add/enable/disable repo functions
