### PR TITLE
require/network.py: remove print

### DIFF
--- a/fabtools/require/network.py
+++ b/fabtools/require/network.py
@@ -37,8 +37,6 @@ def host(ipaddress, hostnames, use_sudo=False):
                     toadd.append(h)
 
             if len(toadd) > 0:
-                print "ADD: %s" % toadd
-                print res
                 hostline = "%s %s" % (res, ' '.join(toadd))
 
                 with hide('stdout', 'warnings'):


### PR DESCRIPTION
found this while doing python3 compat stuff.

slightly related: openvz/contextmanager.py seems to use the print-function, but without an import from __future__. i am pretty sure these code paths will break given that fabtools is python2.