### PR TITLE
fix install fab 1.x 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class Tox(TestCommand):
         sys.exit(errno)
 
 
-fabric_package = 'fabric>=1.7.0'
+fabric_package = 'fabric<2.0'
 if sys.version_info >= (3, 0):  # substitute fabric3 for python 3 environments
     fabric_package = 'fabric3>=1.13.1.post1'
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class Tox(TestCommand):
         sys.exit(errno)
 
 
-fabric_package = 'fabric<2.0'
+fabric_package = 'fabric<2.0.>=1.7.0'
 if sys.version_info >= (3, 0):  # substitute fabric3 for python 3 environments
     fabric_package = 'fabric3>=1.13.1.post1'
 


### PR DESCRIPTION
on fabric documentation

http://www.fabfile.org/installing-1.x.html#basic-installation

Fabric is best installed via pip; to ensure you get Fabric 1 instead of the new but incompatible Fabric 2, specify <2.0: