### PR TITLE
Quote the password before passing to sshpass

### DIFF
--- a/fabtools/mysql.py
+++ b/fabtools/mysql.py
@@ -44,7 +44,7 @@ def query(query, use_sudo=True, **kwargs):
     if password:
         if not is_installed('sshpass'):
             install('sshpass')
-        func_mysql = 'sshpass -p %(password)s mysql' % {'password': password}
+        func_mysql = 'sshpass -p %(password)s mysql' % {'password': quote(password)}
         options.append('--password')
     if mysql_host:
         options.append('--host=%s' % quote(mysql_host))


### PR DESCRIPTION
While all other things being passed are being quoted, `password` gets passed unquoted leading to failure when there are special characters in the password.